### PR TITLE
Bugfix: Quill verliert Fokus bei Klick ins Leere

### DIFF
--- a/src/components/QuillEditor.tsx
+++ b/src/components/QuillEditor.tsx
@@ -291,7 +291,16 @@ export default function QuillEditor({ value, onChange, autoFocus = false }: Quil
   }, [customHandlers]);
 
   return (
-    <div className="w-full min-h-screen bg-gray-50">
+    <div
+      className="w-full min-h-screen bg-gray-50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          const btn = document.getElementById('dummy-blur-button') as HTMLButtonElement | null;
+          btn?.focus();
+        }
+      }}
+    >
+      <button id="dummy-blur-button" className="absolute opacity-0 pointer-events-none" aria-hidden="true" />
       {/* BOLT-UI-ANPASSUNG 2025-01-15: Toolbar wieder oben wie ursprünglich */}
       <div className="main-content w-full">
         {/* BOLT-UI-ANPASSUNG 2025-01-15: Toolbar mit vergrößertem Abstand zur Editorfläche */}


### PR DESCRIPTION
## Summary
- blur Quill editor when clicking on the page background

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc4f2e20c8325a76e4b6f7a9d2cb7