### PR TITLE
Fix quill focus remount issue

### DIFF
--- a/src/components/QuillEditor.tsx
+++ b/src/components/QuillEditor.tsx
@@ -67,11 +67,10 @@ export default function QuillEditor({ value, onChange, autoFocus = false }: Quil
   const [showSettings, setShowSettings] = useState(false);
   const [clipboardError, setClipboardError] = useState<string>('');
 
-  // Focus editor on mount if autoFocus is enabled
+  // Debug: log current autoFocus setting without applying focus
   useEffect(() => {
-    if (autoFocus) {
-      quillRef.current?.focus();
-    }
+    console.debug('QuillEditor autoFocus:', autoFocus);
+    // quillRef.current?.focus();
   }, [autoFocus]);
   
   // Load settings and templates from localStorage


### PR DESCRIPTION
## Summary
- disable auto-focusing when mounting Quill editor
- log current `autoFocus` value for debugging

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bc7de5eb483258c03d5b4c87be6ab