### PR TITLE
Fix QuillEditor autofocus issue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -287,6 +287,14 @@ function App() {
   );
   const [selectedStyles, setSelectedStyles] = useState<string[]>([]);
 
+  useEffect(() => {
+    const input = document.getElementById('dummy-initial-blur') as HTMLInputElement | null;
+    if (input) {
+      input.focus();
+      setTimeout(() => input.blur(), 10);
+    }
+  }, []);
+
   // Load database statistics if Supabase is configured
   useEffect(() => {
     const loadStats = async () => {
@@ -527,8 +535,15 @@ function App() {
         )}
 
         {/* Cover Letter Display */}
-        <CoverLetterDisplay 
-          content={coverLetter} 
+        <input
+          type="text"
+          id="dummy-initial-blur"
+          style={{ opacity: 0, position: "absolute", top: 0, left: 0, zIndex: -1, width: 1, height: 1 }}
+          tabIndex={-1}
+          aria-hidden="true"
+        />
+        <CoverLetterDisplay
+          content={coverLetter}
           isLoading={isGenerating}
           isEditing={isEditing}
           onEdit={handleEdit}

--- a/src/components/ForwardedReactQuill.tsx
+++ b/src/components/ForwardedReactQuill.tsx
@@ -1,10 +1,10 @@
 // src/components/ForwardedReactQuill.tsx
 import React, { forwardRef } from "react";
-import ReactQuill, { ReactQuillProps } from "react-quill";
+import ReactQuill from "react-quill";
 
 // BOLT-UI-ANPASSUNG 2025-01-15: Dieses Forwarding ermöglicht eine korrekte Weitergabe von Refs ohne findDOMNode!
-const ForwardedReactQuill = forwardRef<ReactQuill, ReactQuillProps>((props, ref) => (
-  <ReactQuill ref={ref} {...props} />
+const ForwardedReactQuill = forwardRef((props, ref) => (
+  <ReactQuill {...props} ref={ref} />
 ));
 
 export default ForwardedReactQuill;

--- a/src/components/QuillEditor.tsx
+++ b/src/components/QuillEditor.tsx
@@ -19,7 +19,6 @@ const DEFAULT_SETTINGS: EditorSettings = {
   placeholderEnabled: false, // BOLT-UI-ANPASSUNG 2025-01-15: Platzhalter deaktiviert
   placeholderColor: '#9ca3af',
   readOnly: false,
-  autoFocus: false, // BOLT-UI-ANPASSUNG 2025-01-15: AutoFocus deaktiviert
   toolbarMode: 'wrap',
   toolbarAutoHide: false,
   toolbarPosition: 'top',
@@ -66,14 +65,6 @@ export default function QuillEditor({ value, onChange }: QuillEditorProps) {
   const [showSettings, setShowSettings] = useState(false);
   const [clipboardError, setClipboardError] = useState<string>('');
 
-  // Prevent initial auto focus/cursor after mount
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      const quill = quillRef.current?.getEditor();
-      quill?.root.blur();
-    }, 0);
-    return () => clearTimeout(timer);
-  }, []);
 
   // Load settings and templates from localStorage
   const [settings, setSettings] = useState<EditorSettings>(() => {


### PR DESCRIPTION
## Summary
- prevent Quill editor from focusing on load by using a dummy input in `App`
- adjust `ForwardedReactQuill` implementation
- remove autofocus logic from `QuillEditor`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bcb74002c8325b79e09a730b5c3f2