### PR TITLE
Fix Quill autoFocus behavior

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -287,13 +287,6 @@ function App() {
   );
   const [selectedStyles, setSelectedStyles] = useState<string[]>([]);
 
-  useEffect(() => {
-    const input = document.getElementById('dummy-initial-blur') as HTMLInputElement | null;
-    if (input) {
-      input.focus();
-      setTimeout(() => input.blur(), 10);
-    }
-  }, []);
 
   // Load database statistics if Supabase is configured
   useEffect(() => {
@@ -535,13 +528,6 @@ function App() {
         )}
 
         {/* Cover Letter Display */}
-        <input
-          type="text"
-          id="dummy-initial-blur"
-          style={{ opacity: 0, position: "absolute", top: 0, left: 0, zIndex: -1, width: 1, height: 1 }}
-          tabIndex={-1}
-          aria-hidden="true"
-        />
         <CoverLetterDisplay
           content={coverLetter}
           isLoading={isGenerating}

--- a/src/components/QuillEditor.tsx
+++ b/src/components/QuillEditor.tsx
@@ -19,6 +19,7 @@ const DEFAULT_SETTINGS: EditorSettings = {
   placeholderEnabled: false, // BOLT-UI-ANPASSUNG 2025-01-15: Platzhalter deaktiviert
   placeholderColor: '#9ca3af',
   readOnly: false,
+  autoFocus: false,
   toolbarMode: 'wrap',
   toolbarAutoHide: false,
   toolbarPosition: 'top',
@@ -344,6 +345,7 @@ export default function QuillEditor({ value, onChange }: QuillEditorProps) {
                 modules={modules}
                 formats={formats}
                 placeholder="" // BOLT-UI-ANPASSUNG 2025-01-15: Kein Platzhalter
+                autoFocus={settings.autoFocus}
                 readOnly={settings.readOnly}
                 theme={settings.theme}
                 style={{


### PR DESCRIPTION
## Summary
- disable autoFocus in the default editor settings
- forward the `autoFocus` prop to ReactQuill
- remove dummy focus input and related effect

## Testing
- `npm run lint` *(fails: '_error' is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_686bcea0aa588325a90daa6e4233de87