### PR TITLE
Bugfix: prevent QuillEditor auto focus

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -527,6 +527,15 @@ function App() {
           </div>
         )}
 
+        {/* Dummy input to prevent Quill from grabbing focus automatically */}
+        <input
+          type="text"
+          id="dummy-initial-blur"
+          style={{ opacity: 0, position: "absolute", top: 0, left: 0, zIndex: -1, width: 1, height: 1 }}
+          tabIndex={-1}
+          aria-hidden="true"
+        />
+
         {/* Cover Letter Display */}
         <CoverLetterDisplay
           content={coverLetter}


### PR DESCRIPTION
## Summary
- avoid the editor stealing focus on load by adding a hidden dummy input before the editor

## Testing
- `npm run lint` *(fails: `_error` variables unused)*
- `npm run build` *(fails: missing rollup native module)*

------
https://chatgpt.com/codex/tasks/task_e_686bd8a3ce54832596f80e2c8945caaf