### PR TITLE
Disable default Quill toolbar

### DIFF
--- a/src/components/QuillEditor.tsx
+++ b/src/components/QuillEditor.tsx
@@ -24,7 +24,7 @@ export default function QuillEditor({
 
   const modules = useMemo(
     () => ({
-      toolbar: { container: "#custom-toolbar" },
+      toolbar: false,
       history: { delay: 1000, maxStack: 100, userOnly: true },
     }),
     []


### PR DESCRIPTION
## Summary
- turn off Quill's built-in toolbar so only CustomToolbar is rendered

## Testing
- `npm run lint` *(fails: `_error` is defined but never used`)*

------
https://chatgpt.com/codex/tasks/task_e_686bf19d71ec8325b09a8dd4427889d4