### PR TITLE
Fix Quill auto focus

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -360,6 +360,29 @@ function App() {
     saveToStorage('profileSourceMappings', profileSourceMappings);
   }, [profileSourceMappings]);
 
+  // Prevent Quill from auto-focusing on mount or when clicking outside
+  useEffect(() => {
+    const blurEditor = () => {
+      const active = document.activeElement as HTMLElement | null;
+      if (active && active.classList.contains('ql-editor')) {
+        active.blur();
+      }
+    };
+
+    blurEditor();
+
+    const handleClick = (e: MouseEvent) => {
+      const editor = document.querySelector('.ql-editor');
+      if (editor && !editor.contains(e.target as Node)) {
+        if (document.activeElement === editor) {
+          (editor as HTMLElement).blur();
+        }
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
   // ✅ KORRIGIERT: Memoisiere handleGenerate mit useCallback
   const handleGenerate = useCallback(async () => {
     if (!cvContent.trim() || !jobContent.trim()) {

--- a/src/components/ForwardedReactQuill.tsx
+++ b/src/components/ForwardedReactQuill.tsx
@@ -1,10 +1,46 @@
 // src/components/ForwardedReactQuill.tsx
-import React, { forwardRef } from "react";
+import React, {
+  forwardRef,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import ReactQuill from "react-quill";
 
 // BOLT-UI-ANPASSUNG 2025-01-15: Dieses Forwarding ermöglicht eine korrekte Weitergabe von Refs ohne findDOMNode!
-const ForwardedReactQuill = forwardRef((props, ref) => (
-  <ReactQuill {...props} ref={ref} />
-));
+const ForwardedReactQuill = forwardRef((props: any, ref) => {
+  const innerRef = useRef<ReactQuill | null>(null);
+  const [renderEditor, setRenderEditor] = useState(false);
+
+  // Delay rendering slightly to avoid initial focus
+  useEffect(() => {
+    const id = setTimeout(() => setRenderEditor(true), 50);
+    return () => clearTimeout(id);
+  }, []);
+
+  // Immediately blur after mount so the cursor is not placed automatically
+  useEffect(() => {
+    if (!renderEditor) return;
+    try {
+      const quill = innerRef.current?.getEditor?.();
+      quill?.blur?.();
+    } catch {
+      /* ignored */
+    }
+  }, [renderEditor]);
+
+  const setRefs = (instance: ReactQuill | null) => {
+    innerRef.current = instance;
+    if (typeof ref === "function") {
+      ref(instance);
+    } else if (ref && typeof ref === "object") {
+      (ref as React.MutableRefObject<ReactQuill | null>).current = instance;
+    }
+  };
+
+  const { autoFocus: _ignored, ...rest } = props || {};
+
+  return renderEditor ? <ReactQuill {...rest} ref={setRefs} /> : null;
+});
 
 export default ForwardedReactQuill;

--- a/src/components/QuillEditor.tsx
+++ b/src/components/QuillEditor.tsx
@@ -5,20 +5,19 @@ import {
   useCallback,
   useState,
 } from "react";
-import ReactQuill from "react-quill";
+import type ReactQuill from "react-quill";
+import ForwardedReactQuill from "./ForwardedReactQuill";
 import CustomToolbar from "./CustomToolbar";
 import "react-quill/dist/quill.snow.css";
 
 interface QuillEditorProps {
   value: string;
   onChange: (value: string) => void;
-  autoFocus?: boolean;
 }
 
 export default function QuillEditor({
   value,
   onChange,
-  autoFocus = false,
 }: QuillEditorProps) {
   const editorRef = useRef<ReactQuill | null>(null);
 
@@ -145,14 +144,6 @@ export default function QuillEditor({
 
   const noop = useCallback(() => {}, []);
 
-  useEffect(() => {
-    if (!autoFocus) return;
-    const id = setTimeout(() => {
-      editorRef.current?.focus();
-    });
-    return () => clearTimeout(id);
-  }, [autoFocus]);
-
   return (
     <>
       <CustomToolbar
@@ -173,7 +164,7 @@ export default function QuillEditor({
         minZoom={50}
         maxZoom={200}
       />
-      <ReactQuill
+      <ForwardedReactQuill
         ref={editorRef}
         theme="snow"
         value={value}
@@ -185,3 +176,4 @@ export default function QuillEditor({
     </>
   );
 }
+


### PR DESCRIPTION
## Summary
- wrap ReactQuill with a component that delays rendering and blurs after mount
- use the wrapper in `QuillEditor`
- remove editor `autoFocus` handling
- globally blur the editor when clicking outside

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bf6fde9648325b385220cc54737a5