### PR TITLE
Fix Quill color, background and line height features

### DIFF
--- a/src/components/CustomToolbar.tsx
+++ b/src/components/CustomToolbar.tsx
@@ -601,7 +601,7 @@ export default function CustomToolbar({
       const quill = getQuill();
       if (quill && quill.format) {
         try {
-          quill.format('line-height', value || false);
+          quill.format('lineheight', value || false);
         } catch {
           // BOLT-FIX 2025-01-15: Stille Fehlerbehandlung
         }
@@ -801,7 +801,7 @@ export default function CustomToolbar({
       group: 'color',
       handler: () => {}, // Color picker hat keinen direkten Handler
       element: (
-        <div key="color" className="relative group">
+        <div key="color" className="relative group ql-color">
           <div 
             className="w-7 h-7 border border-gray-300 rounded cursor-pointer flex items-center justify-center"
             title="Textfarbe"
@@ -841,7 +841,7 @@ export default function CustomToolbar({
       group: 'color',
       handler: () => {}, // Color picker hat keinen direkten Handler
       element: (
-        <div key="background" className="relative group">
+        <div key="background" className="relative group ql-background">
           <div 
             className="w-7 h-7 border border-gray-300 rounded cursor-pointer flex items-center justify-center"
             title="Hintergrundfarbe"
@@ -894,12 +894,12 @@ export default function CustomToolbar({
 
     // BOLT-UI-ANPASSUNG 2025-01-15: Zeilenabstand hinzugefügt
     {
-      id: 'line-height',
+      id: 'lineheight',
       priority: 17,
       group: 'style',
       handler: () => {}, // Dropdown hat keinen direkten Handler
       element: (
-        <div key="line-height" className="relative group">
+        <div key="lineheight" className="relative group ql-lineheight">
           <button className="p-2 text-gray-600 hover:text-orange-600 hover:bg-orange-50 rounded-md transition-colors duration-200" title="Zeilenabstand">
             <LineHeightIcon />
           </button>

--- a/src/components/ForwardedReactQuill.tsx
+++ b/src/components/ForwardedReactQuill.tsx
@@ -7,6 +7,7 @@ import React, {
 } from "react";
 import ReactQuill from "react-quill";
 import Quill from "quill";
+import "../quill-custom/LineHeight";
 
 // Register custom font and size whitelists so that selections apply correctly
 const Font = Quill.import("formats/font");
@@ -37,7 +38,10 @@ Size.whitelist = [
 Quill.register(Size, true);
 
 const toolbarConfig = {
-  toolbar: false,
+  toolbar: [
+    [{ color: [] }, { background: [] }],
+    [{ lineheight: ["1", "1.15", "1.5", "2"] }],
+  ],
   history: { delay: 1000, maxStack: 100, userOnly: true },
 };
 
@@ -57,6 +61,7 @@ const formats = [
   "link",
   "color",
   "background",
+  "lineheight",
 ];
 
 // BOLT-UI-ANPASSUNG 2025-01-15: Dieses Forwarding ermöglicht eine korrekte Weitergabe von Refs ohne findDOMNode!

--- a/src/index.css
+++ b/src/index.css
@@ -253,6 +253,19 @@
   font-family: Tahoma, sans-serif !important;
 }
 
+/* Custom Quill pickers */
+.ql-color .ql-picker-item,
+.ql-background .ql-picker-item {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+}
+
+.ql-lineheight .ql-picker-label::before,
+.ql-lineheight .ql-picker-item::before {
+  content: attr(data-value);
+}
+
 /* BOLT-UI-ANPASSUNG 2025-01-15: Zeilenabstand-Styles */
 .ql-editor[style*="line-height: 1"] {
   line-height: 1 !important;

--- a/src/quill-custom/LineHeight.ts
+++ b/src/quill-custom/LineHeight.ts
@@ -1,0 +1,16 @@
+import Quill from "quill";
+
+const Parchment = Quill.import("parchment");
+
+const LineHeightStyle = new (Parchment as any).StyleAttributor(
+  "lineheight",
+  "line-height",
+  {
+    scope: (Parchment as any).Scope.BLOCK,
+    whitelist: ["1", "1.15", "1.5", "2"],
+  }
+);
+
+Quill.register(LineHeightStyle, true);
+
+export default LineHeightStyle;


### PR DESCRIPTION
## Summary
- add custom line height format and register it
- enable color/background pickers in Quill modules
- expose `.ql-color`, `.ql-background`, `.ql-lineheight` via custom toolbar
- add CSS styles for the new Quill classes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bff6e18dc83258c05fa0a7c564dd7