### PR TITLE
Fix line-height StyleAttributor usage

### DIFF
--- a/src/quill-custom/LineHeight.ts
+++ b/src/quill-custom/LineHeight.ts
@@ -1,8 +1,9 @@
 import Quill from "quill";
+import { StyleAttributor } from "parchment";
 
 const Parchment = Quill.import("parchment");
 
-const LineHeightStyle = new (Parchment as any).StyleAttributor(
+const LineHeightStyle = new StyleAttributor(
   "lineheight",
   "line-height",
   {


### PR DESCRIPTION
## Summary
- fix custom line-height plugin to import StyleAttributor directly from `parchment`

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c00f087448325a02e6fe0bf891cac