### PR TITLE
Fix toolbar recognition for custom Quill buttons

### DIFF
--- a/src/components/CustomToolbar.tsx
+++ b/src/components/CustomToolbar.tsx
@@ -33,16 +33,13 @@ export default function CustomToolbar({ quillRef }: CustomToolbarProps) {
   const toolbarRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const quill = quillRef.current?.getEditor?.();
-    const container = toolbarRef.current;
-    if (!quill || !container) return;
-    try {
-      const toolbar = quill.getModule('toolbar');
-      if (toolbar) {
-        toolbar.container = container;
+    if (quillRef.current && toolbarRef.current) {
+      const quill = quillRef.current.getEditor();
+      const toolbarModule = quill.getModule('toolbar');
+      if (toolbarModule) {
+        toolbarModule.container = toolbarRef.current;
+        toolbarModule.init();
       }
-    } catch {
-      /* ignored */
     }
   }, [quillRef]);
 

--- a/src/components/ForwardedReactQuill.tsx
+++ b/src/components/ForwardedReactQuill.tsx
@@ -91,7 +91,7 @@ const ForwardedReactQuill = forwardRef((props: any, ref) => {
   const modules = useMemo(
     () => ({
       ...userModules,
-      toolbar: { toolbar: true },
+      toolbar: true,
       history: userModules.history || DEFAULT_HISTORY,
     }),
     [userModules]


### PR DESCRIPTION
## Summary
- rewire Quill toolbar container to CustomToolbar DOM element
- set modules.toolbar to `true` so Quill uses the DOM toolbar
- list supported formats for Quill editor

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_686c180fa62c8325a58122135acc7430