### PR TITLE
Fix quill toolbar init when ref is undefined

### DIFF
--- a/src/components/CustomToolbar.tsx
+++ b/src/components/CustomToolbar.tsx
@@ -15,12 +15,16 @@ export default function CustomToolbar({ quillRef }: CustomToolbarProps) {
   const [showAdvanced, setShowAdvanced] = useState(false);
 
   useEffect(() => {
-    if (quillRef.current && toolbarRef.current) {
-      const quill = quillRef.current.getEditor();
-      const toolbarModule = quill.getModule('toolbar');
-      if (toolbarModule && toolbarModule.container !== toolbarRef.current) {
+    if (!quillRef?.current || !toolbarRef.current) return;
+
+    try {
+      const quill = quillRef.current.getEditor?.();
+      const toolbarModule = quill?.getModule?.('toolbar');
+      if (toolbarModule && toolbarRef.current) {
         toolbarModule.container = toolbarRef.current;
       }
+    } catch {
+      // sicher ignorieren, wenn Quill noch nicht bereit ist
     }
   }, [quillRef]);
 


### PR DESCRIPTION
## Summary
- guard against undefined `quillRef` when assigning the custom toolbar

## Testing
- `npm run lint` *(fails: several unused variable errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c2b9843688325924f8c3c06b81d70