### PR TITLE
Implement editCoverLetter for Mistral

### DIFF
--- a/src/services/mistralService.ts
+++ b/src/services/mistralService.ts
@@ -22,3 +22,34 @@ export async function generateText(prompt: string, config: KIModelSettings) {
   const data = await res.json();
   return data.choices?.[0]?.message?.content ?? "";
 }
+
+export async function editCoverLetter(
+  prompt: string,
+  systemPrompt: string,
+  config: KIModelSettings,
+) {
+  const body = {
+    model: config.model,
+    temperature: config.temperature,
+    top_p: config.top_p,
+    max_tokens: config.max_tokens,
+    messages: [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: prompt },
+    ],
+  };
+
+  const res = await fetch(config.endpoint, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${config.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) throw new Error("KI-Antwort fehlgeschlagen.");
+  const data = await res.json();
+  return data.choices?.[0]?.message?.content ?? "";
+}
+


### PR DESCRIPTION
## Summary
- extend the Mistral service with an `editCoverLetter` function
- expose the new method via named export

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686cc8b60cf48325abbe4c06449798d1