### PR TITLE
Implement getDatabaseStats

### DIFF
--- a/src/services/supabaseService.ts
+++ b/src/services/supabaseService.ts
@@ -18,3 +18,25 @@ export async function saveKIConfigs(models: KIModelSettings[]) {
     console.error("Fehler beim Speichern der KI-Konfigurationen:", error.message);
   }
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function getDatabaseStats(): Promise<any> {
+  try {
+    const { data, error } = await supabase
+      .from("usage_stats")
+      .select("*")
+      .order("timestamp", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) {
+      console.error("Fehler beim Abrufen der Datenbankstatistiken:", error.message);
+      return null;
+    }
+
+    return data ?? null;
+  } catch (err) {
+    console.error("Unerwarteter Fehler beim Abrufen der Datenbankstatistiken:", err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add `getDatabaseStats` in `supabaseService`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686cce5d50d88325a3bafa28e3d28421