### PR TITLE
Create ki_settings migration

### DIFF
--- a/supabase/migrations/20250610120000_add_ki_settings.sql
+++ b/supabase/migrations/20250610120000_add_ki_settings.sql
@@ -1,0 +1,13 @@
+-- Create ki_settings table for configurable KI models
+
+CREATE TABLE IF NOT EXISTS public.ki_settings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  model text NOT NULL,
+  endpoint text NOT NULL,
+  api_key text,
+  temperature numeric DEFAULT 0.7,
+  top_p numeric DEFAULT 1.0,
+  max_tokens integer DEFAULT 2048,
+  is_active boolean DEFAULT true,
+  created_at timestamptz DEFAULT current_timestamp
+);


### PR DESCRIPTION
## Summary
- add migration for new `ki_settings` table

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686cdd629e1883259704558251eb5f6e