### PR TITLE
Fix SettingsPage modal toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -446,7 +446,10 @@ function App() {
           {/* BOLT-UI-ANPASSUNG 2025-01-15: Nur Zahnradsymbol oben rechts */}
           <div className="absolute top-0 right-0">
             <button
-              onClick={() => setShowSettings(true)}
+              onClick={() => {
+                console.log("Settings-Button geklickt");
+                setShowSettings(true);
+              }}
               className="flex items-center p-2 bg-white rounded-lg shadow-sm border hover:bg-gray-50 transition-colors duration-200"
               title="App-Konfiguration öffnen"
             >
@@ -469,14 +472,6 @@ function App() {
         <SettingsPage
           isOpen={showSettings}
           onClose={() => setShowSettings(false)}
-          documentTypes={documentTypes}
-          onDocumentTypesChange={setDocumentTypes}
-          editPrompts={editPrompts}
-          onEditPromptsChange={setEditPrompts}
-          stylePrompts={stylePrompts}
-          onStylePromptsChange={setStylePrompts}
-          profileSourceMappings={profileSourceMappings}
-          onProfileSourceMappingsChange={setProfileSourceMappings}
         />
 
         {/* Document Type Selector */}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,13 +1,20 @@
 import { useEffect, useState } from "react";
+import { X } from "lucide-react";
 import { KIModelSettings } from "../types/KIModelSettings";
 import { defaultKIModels } from "../constants/kiDefaults";
 import { loadKIConfigs, saveKIConfigs } from "../services/supabaseService";
 import SettingsModal from "./SettingsModal";
 
-export default function SettingsPage() {
+interface SettingsPageProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function SettingsPage({ isOpen, onClose }: SettingsPageProps) {
   const [models, setModels] = useState<KIModelSettings[]>([]);
 
   useEffect(() => {
+    if (!isOpen) return;
     const fetch = async () => {
       const fromDB = await loadKIConfigs();
       const merged = defaultKIModels.map((def) =>
@@ -16,12 +23,28 @@ export default function SettingsPage() {
       setModels(merged);
     };
     fetch();
-  }, []);
+  }, [isOpen]);
 
   const handleSave = async (updatedModels: KIModelSettings[]) => {
     await saveKIConfigs(updatedModels);
     setModels(updatedModels);
   };
 
-  return <SettingsModal models={models} onSave={handleSave} />;
+  if (!isOpen) return null;
+
+  console.log("SettingsPage gerendert");
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-xl max-h-[95vh] overflow-y-auto p-6 relative">
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-gray-400 hover:text-gray-600"
+        >
+          <X className="h-6 w-6" />
+        </button>
+        <SettingsModal models={models} onSave={handleSave} />
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- implement `isOpen` and `onClose` props for `SettingsPage`
- render `SettingsPage` as modal overlay and log render action
- log when the settings button is clicked
- simplify usage of `SettingsPage` in `App`

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686cdebc8c3483258f6fd64a415e360e