### PR TITLE
Enable settings page via router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "mammoth": "^1.6.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-quill": "^2.0.0"
+        "react-quill": "^2.0.0",
+        "react-router-dom": "^6.23.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -997,6 +998,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3998,6 +4008,38 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "mammoth": "^1.6.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-quill": "^2.0.0"
+    "react-quill": "^2.0.0",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { User, Briefcase, Sparkles, AlertTriangle, Settings } from 'lucide-react';
+import { Routes, Route, useNavigate } from 'react-router-dom';
 import InputSection from './components/InputSection';
 import CoverLetterDisplay from './components/CoverLetterDisplay';
 import StyleSelector from './components/StyleSelector';
@@ -257,7 +258,8 @@ function saveToStorage<T>(key: string, value: T): void {
   }
 }
 
-function App() {
+function HomePage() {
+  const navigate = useNavigate();
   const [cvContent, setCvContent] = useState('');
   const [jobContent, setJobContent] = useState('');
   const [coverLetter, setCoverLetter] = useState('');
@@ -265,25 +267,24 @@ function App() {
   const [isEditing, setIsEditing] = useState(false);
   const [error, setError] = useState('');
   const [databaseStats, setDatabaseStats] = useState<DatabaseStats | null>(null);
-  const [showSettings, setShowSettings] = useState(false);
   
   // Load settings from localStorage with defaults
-  const [documentTypes, setDocumentTypes] = useState(() => 
+  const [documentTypes] = useState(() =>
     loadFromStorage('documentTypes', DEFAULT_DOCUMENT_TYPES)
   );
   const [selectedDocumentType, setSelectedDocumentType] = useState(() => 
     loadFromStorage('selectedDocumentType', 'standard')
   );
-  const [editPrompts, setEditPrompts] = useState(() => 
+  const [editPrompts] = useState(() =>
     loadFromStorage('editPrompts', DEFAULT_EDIT_PROMPTS)
   );
-  const [stylePrompts, setStylePrompts] = useState(() => 
+  const [stylePrompts] = useState(() =>
     loadFromStorage('stylePrompts', DEFAULT_STYLE_PROMPTS)
   );
   const [profileConfig, setProfileConfig] = useState<ProfileConfig>(() => 
     loadProfileConfigFromStorage()
   );
-  const [profileSourceMappings, setProfileSourceMappings] = useState<ProfileSourceMapping[]>(() =>
+  const [profileSourceMappings] = useState<ProfileSourceMapping[]>(() =>
     loadProfileSourceMappingsFromStorage()
   );
   const [selectedStyles, setSelectedStyles] = useState<string[]>([]);
@@ -446,10 +447,7 @@ function App() {
           {/* BOLT-UI-ANPASSUNG 2025-01-15: Nur Zahnradsymbol oben rechts */}
           <div className="absolute top-0 right-0">
             <button
-              onClick={() => {
-                console.log("Settings-Button geklickt");
-                setShowSettings(true);
-              }}
+              onClick={() => navigate('/settings')}
               className="flex items-center p-2 bg-white rounded-lg shadow-sm border hover:bg-gray-50 transition-colors duration-200"
               title="App-Konfiguration öffnen"
             >
@@ -467,12 +465,6 @@ function App() {
             </h1>
           </div>
         </div>
-
-        {/* Settings Modal */}
-        <SettingsPage
-          isOpen={showSettings}
-          onClose={() => setShowSettings(false)}
-        />
 
         {/* Document Type Selector */}
         <DocumentTypeSelector
@@ -574,6 +566,15 @@ function App() {
         </div>
       </div>
     </div>
+  );
+}
+
+function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<HomePage />} />
+      <Route path="/settings" element={<SettingsPage />} />
+    </Routes>
   );
 }
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,20 +1,16 @@
 import { useEffect, useState } from "react";
 import { X } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 import { KIModelSettings } from "../types/KIModelSettings";
 import { defaultKIModels } from "../constants/kiDefaults";
 import { loadKIConfigs, saveKIConfigs } from "../services/supabaseService";
 import SettingsModal from "./SettingsModal";
 
-interface SettingsPageProps {
-  isOpen: boolean;
-  onClose: () => void;
-}
-
-export default function SettingsPage({ isOpen, onClose }: SettingsPageProps) {
+export default function SettingsPage() {
+  const navigate = useNavigate();
   const [models, setModels] = useState<KIModelSettings[]>([]);
 
   useEffect(() => {
-    if (!isOpen) return;
     const fetch = async () => {
       const fromDB = await loadKIConfigs();
       const merged = defaultKIModels.map((def) =>
@@ -23,14 +19,13 @@ export default function SettingsPage({ isOpen, onClose }: SettingsPageProps) {
       setModels(merged);
     };
     fetch();
-  }, [isOpen]);
+  }, []);
 
   const handleSave = async (updatedModels: KIModelSettings[]) => {
     await saveKIConfigs(updatedModels);
     setModels(updatedModels);
   };
 
-  if (!isOpen) return null;
 
   console.log("SettingsPage gerendert");
 
@@ -38,7 +33,7 @@ export default function SettingsPage({ isOpen, onClose }: SettingsPageProps) {
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-lg shadow-xl w-full max-w-xl max-h-[95vh] overflow-y-auto p-6 relative">
         <button
-          onClick={onClose}
+          onClick={() => navigate(-1)}
           className="absolute top-4 right-4 text-gray-400 hover:text-gray-600"
         >
           <X className="h-6 w-6" />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import 'react-quill/dist/quill.snow.css';
 
@@ -7,5 +8,9 @@ import 'react-quill/dist/quill.snow.css';
 const container = document.getElementById('root');
 
 if (container) {
-  createRoot(container).render(<App />);
+  createRoot(container).render(
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  );
 }


### PR DESCRIPTION
## Summary
- add `react-router-dom` dependency
- wrap app in `BrowserRouter`
- replace settings modal with route navigation
- implement a settings route

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ce1ee6ef08325badd36b6d08392ae