### PR TITLE
Fix supabase table queries

### DIFF
--- a/src/components/DatabaseMappingSection.tsx
+++ b/src/components/DatabaseMappingSection.tsx
@@ -38,9 +38,8 @@ export default function DatabaseMappingSection() {
   useEffect(() => {
     const fetchTables = async () => {
       const { data, error } = await supabase
-        .from('information_schema.tables')
-        .select('table_name')
-        .eq('table_schema', 'public');
+        .from('available_tables')
+        .select('table_name');
       if (error) {
         console.error('Tabellen konnten nicht geladen werden:', error.message);
       } else {
@@ -56,7 +55,7 @@ export default function DatabaseMappingSection() {
 
     const fetchColumns = async () => {
       const { data, error } = await supabase
-        .from('information_schema.columns')
+        .from('available_columns')
         .select('column_name')
         .eq('table_name', tableName);
       if (error) {

--- a/src/services/supabaseService.ts
+++ b/src/services/supabaseService.ts
@@ -69,10 +69,8 @@ async function getSupabaseTableNames(forceRefresh = false): Promise<SupabaseTabl
   }
 
   const { data, error } = await supabase
-    .from('pg_catalog.pg_tables')
-    .select('tablename, schemaname')
-    .neq('schemaname', 'pg_catalog')
-    .neq('schemaname', 'information_schema');
+    .from('available_tables')
+    .select('table_name');
 
   if (error) {
     console.error('Error fetching tables:', error.message);
@@ -80,9 +78,9 @@ async function getSupabaseTableNames(forceRefresh = false): Promise<SupabaseTabl
   }
 
   const tables: SupabaseTable[] = [];
-  for (const row of data as { tablename: string }[]) {
-    const columns = await getTableColumns(row.tablename);
-    tables.push({ table_name: row.tablename, columns });
+  for (const row of data as { table_name: string }[]) {
+    const columns = await getTableColumns(row.table_name);
+    tables.push({ table_name: row.table_name, columns });
   }
 
   tableCache = { timestamp: Date.now(), tables };
@@ -106,9 +104,9 @@ async function testTableColumnMapping(table: string, column: string) {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function getDatabaseStats(): Promise<any> {
   const { data, error } = await supabase
-    .from("usage_stats")
-    .select("*")
-    .order("timestamp", { ascending: false })
+    .from('system_status')
+    .select('*')
+    .order('timestamp', { ascending: false })
     .limit(1);
 
   if (error) {
@@ -167,10 +165,10 @@ async function testDatabaseConnection(): Promise<boolean> {
 
 async function fetchTableColumns(tableName: string): Promise<string[]> {
   const { data, error } = await supabase
-    .from('information_schema.columns')
+    .from('available_columns')
     .select('column_name')
     .eq('table_name', tableName)
-    .order('ordinal_position');
+    .order('column_name');
 
   if (error) {
     console.error('Error fetching table columns:', error.message);

--- a/supabase/migrations/20250708141000_add_available_tables_and_system_status.sql
+++ b/supabase/migrations/20250708141000_add_available_tables_and_system_status.sql
@@ -1,0 +1,20 @@
+-- View exposing table names in the public schema
+create or replace view public.available_tables as
+select table_name
+from information_schema.tables
+where table_schema = 'public'
+  and table_type = 'BASE TABLE';
+
+-- View exposing column names for public tables
+create or replace view public.available_columns as
+select table_name, column_name
+from information_schema.columns
+where table_schema = 'public';
+
+-- Optional table for storing system status metrics
+create table if not exists public.system_status (
+  id serial primary key,
+  name text,
+  status text,
+  timestamp timestamptz default now()
+);


### PR DESCRIPTION
## Summary
- add migration with `available_tables`, `available_columns`, and `system_status`
- fetch table and column lists via new public views
- switch stats query to new `system_status` table

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d25e4183c8325a0a7f112b93df3d3