### PR TITLE
Reduce re-renders in settings

### DIFF
--- a/src/components/DatabaseMappingSection.tsx
+++ b/src/components/DatabaseMappingSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Database as DatabaseIcon, Plus, Trash2 } from 'lucide-react';
 import { getFieldMappings } from '../services/supabaseService';
 
@@ -27,7 +27,7 @@ const loadInitial = () => {
   return { tableName: '', isActive: true, mappings: [] as MappingRow[] };
 };
 
-export default function DatabaseMappingSection() {
+function DatabaseMappingSection() {
   // Use lazy initial state to prevent re-execution
   const [state, setState] = useState(loadInitial);
   const { tableName, isActive, mappings } = state;
@@ -213,5 +213,6 @@ export default function DatabaseMappingSection() {
         </button>
       </div>
     </div>
-  );
-}
+  );}
+
+export default React.memo(DatabaseMappingSection);

--- a/src/components/DatabaseStatus.tsx
+++ b/src/components/DatabaseStatus.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Database, CheckCircle, XCircle, AlertCircle, RefreshCw } from 'lucide-react';
 import {
   isSupabaseConfigured,
@@ -8,7 +8,7 @@ import {
   type DatabaseStats
 } from '../services/supabaseService';
 
-export default function DatabaseStatus() {
+function DatabaseStatus() {
   const [isConfigured, setIsConfigured] = useState(false);
   const [isConnected, setIsConnected] = useState(false);
   // DatabaseStats describes the metrics returned from getDatabaseStats
@@ -136,5 +136,6 @@ export default function DatabaseStatus() {
         )}
       </div>
     </div>
-  );
-}
+  );}
+
+export default React.memo(DatabaseStatus);

--- a/src/components/ProfileSourceSettings.tsx
+++ b/src/components/ProfileSourceSettings.tsx
@@ -22,9 +22,9 @@ const CATEGORY_LABELS = {
   ausbildung: 'Ausbildung/Qualifikationen'
 };
 
-export default function ProfileSourceSettings({ 
-  sourceMappings, 
-  onSourceMappingsChange 
+function ProfileSourceSettings({
+  sourceMappings,
+  onSourceMappingsChange
 }: ProfileSourceSettingsProps) {
   const [availableTables, setAvailableTables] = useState<SupabaseTable[]>([]);
   const [isLoadingTables, setIsLoadingTables] = useState(false);
@@ -516,5 +516,6 @@ export default function ProfileSourceSettings({
         </ul>
       </div>
     </div>
-  );
-}
+  );}
+
+export default React.memo(ProfileSourceSettings);

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -82,22 +82,22 @@ const TABS = [
 ] as const;
 
 // Helper functions moved outside component to prevent re-creation
-const loadFromLocalStorage = (key: string, defaultValue: any) => {
+function loadFromLocalStorage<T>(key: string, defaultValue: T): T {
   try {
     const saved = localStorage.getItem(key);
-    return saved ? JSON.parse(saved) : defaultValue;
+    return saved ? (JSON.parse(saved) as T) : defaultValue;
   } catch {
     return defaultValue;
   }
-};
+}
 
-const saveToLocalStorage = (key: string, value: any) => {
+function saveToLocalStorage<T>(key: string, value: T): void {
   try {
     localStorage.setItem(key, JSON.stringify(value));
   } catch (error) {
     console.error(`Error saving ${key} to localStorage:`, error);
   }
-};
+}
 
 export default function SettingsPage() {
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- wrap database components with `React.memo` to avoid unnecessary renders
- fix lint issues in `SettingsPage` by adding generic helpers

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686d4bdf26508325a90ca2d3ada22da5