### PR TITLE
Fix KI model UUIDs

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -194,7 +194,7 @@ export default function SettingsPage() {
 
   const addModel = useCallback(() => {
     const newModel: KIModelSettings = {
-      id: `model_${Date.now()}`,
+      id: crypto.randomUUID(),
       name: 'Neues Modell',
       apiKey: '',
       endpoint: ENDPOINT_MAP['mistral-7b-instruct'],

--- a/src/constants/kiDefaults.ts
+++ b/src/constants/kiDefaults.ts
@@ -2,7 +2,7 @@ import { KIModelSettings } from "../types/KIModelSettings";
 
 export const defaultKIModels: KIModelSettings[] = [
   {
-    id: "mistral",
+    id: "17b3549d-999f-459c-ad3f-08b472113bac",
     model: "mistral-7b-instruct",
     endpoint: "https://api.mistral.ai/v1/chat/completions",
     api_key: "",
@@ -12,7 +12,7 @@ export const defaultKIModels: KIModelSettings[] = [
     active: true,
   },
   {
-    id: "mixtral",
+    id: "09b8ef48-4099-479a-bcaa-8942990c4d60",
     model: "mixtral-8x7b-instruct",
     endpoint: "https://api.mistral.ai/v1/chat/completions",
     api_key: "",
@@ -20,5 +20,4 @@ export const defaultKIModels: KIModelSettings[] = [
     top_p: 0.95,
     max_tokens: 2048,
     active: false,
-  }
-];
+  }];


### PR DESCRIPTION
## Summary
- assign stable UUIDs to built-in KI models
- use `crypto.randomUUID()` when adding new models

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d573b2ad483259177e6620c17bcf3