### PR TITLE
Fix model validation and lint warning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -409,8 +409,8 @@ function HomePage() {
       return;
     }
 
-    if (!activeKIModel) {
-      setError('Kein KI-Modell verfügbar.');
+    if (!activeKIModel || !activeKIModel.model) {
+      setError('Fehler: Kein aktives Modell konfiguriert oder Modellbezeichnung fehlt.');
       return;
     }
 

--- a/src/services/supabaseService.ts
+++ b/src/services/supabaseService.ts
@@ -62,7 +62,11 @@ async function loadKIConfigs(): Promise<KIModelSettings[]> {
 }
 
 async function saveKIConfigs(models: KIModelSettings[]) {
-  const modelsToSave = models.map(({ name, ...rest }) => rest);
+  const modelsToSave = models.map((model) => {
+    const { name, ...rest } = model;
+    void name;
+    return rest;
+  });
   const { error } = await supabase.from("ki_settings").upsert(modelsToSave, {
     onConflict: "id",
   });


### PR DESCRIPTION
## Summary
- guard against missing active model name
- avoid unused variable warning in `saveKIConfigs`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d69292f44832590c561617fb4a601