### PR TITLE
Remove DatabaseMappingSection from SettingsPage

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -15,7 +15,6 @@ import SettingsModal from './SettingsModal';
 import TemplateManagerModal, { Template } from './TemplateManagerModal';
 import ProfileSourceSettings from './ProfileSourceSettings';
 import DatabaseStatus from './DatabaseStatus';
-import DatabaseMappingSection from './DatabaseMappingSection';
 import KIModelSettingsItem from './KIModelSettingsItem';
 import { KIModelSettings } from '../types/KIModelSettings';
 import { defaultKIModels } from '../constants/kiDefaults';
@@ -611,7 +610,6 @@ export default function SettingsPage() {
                   sourceMappings={profileSourceMappings}
                   onSourceMappingsChange={setProfileSourceMappings}
                 />
-                <DatabaseMappingSection />
               </div>
             )}
 


### PR DESCRIPTION
## Summary
- remove the unused `DatabaseMappingSection` from `SettingsPage`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d7b5e22588325ab953106127daef9