### PR TITLE
Fix duplicate getDatabaseStats export

### DIFF
--- a/src/services/supabaseService.ts
+++ b/src/services/supabaseService.ts
@@ -130,7 +130,7 @@ async function testTableColumnMapping(table: string, column: string) {
   return { success: true, sampleData: samples };
 }
 
-export async function getDatabaseStats(
+async function getDatabaseStats(
   mappings: ProfileSourceMapping[] = []
 ): Promise<DatabaseStats> {
   const counts: Record<keyof ProfileConfig, number> = {


### PR DESCRIPTION
## Summary
- remove redundant `export` keyword from `getDatabaseStats`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d7eadfe54832598154fff60591e88