### PR TITLE
Refactor database mapping UI

### DIFF
--- a/src/components/DatabaseStatus.tsx
+++ b/src/components/DatabaseStatus.tsx
@@ -10,6 +10,7 @@ function DatabaseStatus() {
   const [isConnected, setIsConnected] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [connStatus, setConnStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
 
   const checkStatus = useCallback(async () => {
     setIsLoading(true);
@@ -32,25 +33,54 @@ function DatabaseStatus() {
     }
   }, []);
 
+  const handleTestSupabase = useCallback(async () => {
+    setConnStatus('loading');
+    try {
+      const ok = await testSupabaseConnection();
+      setConnStatus(ok ? 'success' : 'error');
+    } catch (err) {
+      console.error('Supabase test error:', err);
+      setConnStatus('error');
+    }
+  }, []);
+
   useEffect(() => {
     checkStatus();
   }, [checkStatus]);
 
   return (
     <div className="bg-white rounded-lg shadow-md p-6 border border-gray-200 mb-8">
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex items-start justify-between mb-4">
         <div className="flex items-center space-x-3">
           <Database className="h-6 w-6" style={{ color: '#F29400' }} />
-          <h2 className="text-xl font-semibold text-gray-900">Datenbank-Status</h2>
         </div>
-        <button
-          onClick={checkStatus}
-          disabled={isLoading}
-          className="flex items-center space-x-2 px-3 py-2 bg-blue-600 text-white hover:bg-blue-700 rounded-lg transition-colors duration-200 disabled:opacity-50"
-        >
-          <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
-          <span>Aktualisieren</span>
-        </button>
+        <div className="flex justify-end space-x-2">
+          <button
+            onClick={handleTestSupabase}
+            disabled={connStatus === 'loading'}
+            className={`px-3 py-1 text-sm h-8 rounded-md text-white ${
+              connStatus === 'success'
+                ? 'bg-green-600'
+                : connStatus === 'error'
+                ? 'bg-red-600'
+                : 'bg-blue-600'
+            }`}
+          >
+            {connStatus === 'success'
+              ? 'Verbindung erfolgreich'
+              : connStatus === 'error'
+              ? 'Verbindung fehlgeschlagen'
+              : 'Supabase testen'}
+          </button>
+          <button
+            onClick={checkStatus}
+            disabled={isLoading}
+            className="flex items-center space-x-2 px-3 py-1 text-sm h-8 bg-blue-600 text-white hover:bg-blue-700 rounded-md transition-colors duration-200 disabled:opacity-50"
+          >
+            <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
+            <span>Aktualisieren</span>
+          </button>
+        </div>
       </div>
 
       <div className="space-y-4">

--- a/src/components/DatabaseStatusPanel.tsx
+++ b/src/components/DatabaseStatusPanel.tsx
@@ -41,7 +41,6 @@ export default function DatabaseStatusPanel() {
     <div className="bg-white rounded-lg shadow-md p-6 border border-gray-200 space-y-4">
       <div className="flex items-center space-x-3">
         <DatabaseIcon className="h-6 w-6" style={{ color: '#F29400' }} />
-        <h3 className="text-lg font-medium text-gray-900">Datenbankstatus</h3>
       </div>
       <div className="flex items-center space-x-2">
         {renderIcon()}

--- a/src/components/ProfileSourceSettings.tsx
+++ b/src/components/ProfileSourceSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Database, Plus, Trash2, X, AlertCircle, RefreshCw, TestTube, Search } from 'lucide-react';
+import { Database, Plus, Trash2, X, AlertCircle, RefreshCw, TestTube } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { 
   getSupabaseTableNames, 
@@ -83,6 +83,19 @@ function ProfileSourceSettings({
     }, [table, column]);
 
     return count;
+  };
+
+  const ColumnCount: React.FC<{ table: string; column: string }> = ({ table, column }) => {
+    const count = useColumnCount(table, column);
+    return (
+      <span className="text-slate-600 text-sm ml-2">
+        {count === undefined
+          ? '?'
+          : count === null
+          ? 'keine Daten'
+          : `${count} Einträge`}
+      </span>
+    );
   };
 
   const loadTables = useCallback(async (forceRefresh: boolean = false) => {
@@ -220,9 +233,6 @@ function ProfileSourceSettings({
       <div className="flex items-center justify-between">
         <div>
           <h3 className="text-lg font-medium text-gray-900">Datenquellen-Zuordnungen</h3>
-          <p className="text-sm text-gray-600 mt-1">
-            Ordnen Sie Profilkategorien zu spezifischen Tabellen und Spalten in Ihrer Supabase-Datenbank zu.
-          </p>
           {lastRefreshTime && (
             <p className="text-xs text-gray-500 mt-1">
               Letzte Aktualisierung: {lastRefreshTime.toLocaleTimeString('de-DE')}
@@ -233,7 +243,7 @@ function ProfileSourceSettings({
           <button
             onClick={() => loadTables(true)}
             disabled={isLoadingTables}
-            className="flex items-center space-x-2 px-3 py-2 text-white hover:opacity-90 rounded-lg transition-colors duration-200 disabled:opacity-50"
+            className="flex items-center space-x-2 px-3 py-1 text-sm h-8 text-white hover:opacity-90 rounded-lg transition-colors duration-200 disabled:opacity-50"
             style={{ backgroundColor: '#F29400' }}
             title="Lädt alle Tabellen neu und invalidiert den Cache"
           >
@@ -242,7 +252,7 @@ function ProfileSourceSettings({
           </button>
           <button
             onClick={() => setShowNewMappingForm(true)}
-            className="flex items-center space-x-2 px-4 py-2 text-white rounded-lg transition-colors duration-200"
+            className="flex items-center space-x-2 px-3 py-1 text-sm h-8 text-white rounded-lg transition-colors duration-200"
             style={{ backgroundColor: '#F29400' }}
           >
             <Plus className="h-4 w-4" />
@@ -408,7 +418,6 @@ function ProfileSourceSettings({
             {sourceMappings.map((mapping, index) => {
               const testKey = `${mapping.tableName}.${mapping.columnName}`;
               const testResult = testResults[testKey];
-              const count = useColumnCount(mapping.tableName, mapping.columnName);
               
               return (
                 <div key={index} className={`border rounded-lg p-4 ${
@@ -429,13 +438,7 @@ function ProfileSourceSettings({
                         <span className="font-medium text-gray-900">
                           {mapping.tableName}.{mapping.columnName}
                         </span>
-                        <span className="text-slate-600 text-sm ml-2">
-                          {count === undefined
-                            ? '?'
-                            : count === null
-                            ? 'keine Daten'
-                            : `${count} Einträge`}
-                        </span>
+                        <ColumnCount table={mapping.tableName} column={mapping.columnName} />
                         {mapping.isActive && (
                           <span className="px-2 py-1 text-white text-xs rounded-full" style={{ backgroundColor: '#F29400' }}>
                             Aktiv

--- a/src/components/PromptTemplateManager.tsx
+++ b/src/components/PromptTemplateManager.tsx
@@ -39,7 +39,8 @@ export default function PromptTemplateManager({
   };
 
   const handleDelete = (cat: keyof PromptState, key: string) => {
-    const { [key]: _removed, ...rest } = prompts[cat];
+    const rest = { ...prompts[cat] };
+    delete rest[key];
     onChange({ ...prompts, [cat]: rest });
   };
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -18,13 +18,12 @@ import DatabaseStatus from './DatabaseStatus';
 import KIModelSettingsItem from './KIModelSettingsItem';
 import PromptTemplateManager from './PromptTemplateManager';
 import { KIModelSettings } from '../types/KIModelSettings';
-import { PromptConfig, PromptState } from '../types/Prompt';
+import { PromptState } from '../types/Prompt';
 import { defaultKIModels } from '../constants/kiDefaults';
 import {
   loadKIConfigs,
   saveKIConfigs,
-  ProfileSourceMapping,
-  testSupabaseConnection
+  ProfileSourceMapping
 } from '../services/supabaseService';
 
 // Tabs handled in this page
@@ -79,7 +78,6 @@ export default function SettingsPage() {
   const [models, setModels] = useState<KIModelSettings[]>([]);
   const [showModelModal, setShowModelModal] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
-  const [connStatus, setConnStatus] = useState<'idle' | 'success' | 'error' | 'loading'>('idle');
   
   // Prompt state
   const [prompts, setPrompts] = useState<PromptState>({
@@ -231,16 +229,6 @@ export default function SettingsPage() {
     }
   }, [models, prompts, autoloadPrompts, defaultStyle, templates, profileSourceMappings, navigate]);
 
-  const handleTestSupabase = useCallback(async () => {
-    setConnStatus('loading');
-    try {
-      const ok = await testSupabaseConnection();
-      setConnStatus(ok ? 'success' : 'error');
-    } catch (error) {
-      console.error('Supabase test error:', error);
-      setConnStatus('error');
-    }
-  }, []);
 
   const handleExport = useCallback(() => {
     const dbMapping = loadFromLocalStorage('databaseMapping', null);
@@ -433,26 +421,6 @@ export default function SettingsPage() {
 
             {activeTab === 'database' && (
               <div className="space-y-6">
-                <div className="flex justify-between items-center">
-                  <h3 className="text-lg font-semibold">Datenbankstatus</h3>
-                  <button
-                    onClick={handleTestSupabase}
-                    disabled={connStatus === 'loading'}
-                    className={`px-3 py-2 text-white rounded-md text-sm ${
-                      connStatus === 'success'
-                        ? 'bg-green-600'
-                        : connStatus === 'error'
-                        ? 'bg-red-600'
-                        : 'bg-blue-600'
-                    }`}
-                  >
-                    {connStatus === 'success'
-                      ? 'Verbindung erfolgreich'
-                      : connStatus === 'error'
-                      ? 'Verbindung fehlgeschlagen'
-                      : 'Supabase testen'}
-                  </button>
-                </div>
                 <DatabaseStatus />
                 <ProfileSourceSettings
                   sourceMappings={profileSourceMappings}


### PR DESCRIPTION
## Summary
- streamline ProfileSourceSettings by removing intro text
- resize mapping buttons for a compact look
- embed database test button in DatabaseStatus
- drop redundant headings for minimalism
- tidy up unused code and hooks

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686e13c12178832593d7ea6fa6fe5c9c