### PR TITLE
Update DB status heading

### DIFF
--- a/src/components/DatabaseStatus.tsx
+++ b/src/components/DatabaseStatus.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Database, CheckCircle, XCircle, AlertCircle, RefreshCw } from 'lucide-react';
+import { CheckCircle, XCircle, AlertCircle } from 'lucide-react';
 import {
   isSupabaseConfigured,
   testSupabaseConnection
@@ -50,11 +50,9 @@ function DatabaseStatus() {
 
   return (
     <div className="bg-white rounded-lg shadow-md p-6 border border-gray-200 mb-8">
-      <div className="flex items-start justify-between mb-4">
-        <div className="flex items-center space-x-3">
-          <Database className="h-6 w-6" style={{ color: '#F29400' }} />
-        </div>
-        <div className="flex justify-end space-x-2">
+      <div className="flex justify-between items-center mb-2">
+        <h2 className="text-lg font-semibold">Datenbankstatus</h2>
+        <div className="flex gap-2">
           <button
             onClick={handleTestSupabase}
             disabled={connStatus === 'loading'}
@@ -75,10 +73,9 @@ function DatabaseStatus() {
           <button
             onClick={checkStatus}
             disabled={isLoading}
-            className="flex items-center space-x-2 px-3 py-1 text-sm h-8 bg-blue-600 text-white hover:bg-blue-700 rounded-md transition-colors duration-200 disabled:opacity-50"
+            className="px-3 py-1 text-sm h-8 bg-blue-600 text-white hover:bg-blue-700 rounded-md transition-colors duration-200 disabled:opacity-50"
           >
-            <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
-            <span>Aktualisieren</span>
+            Aktualisieren
           </button>
         </div>
       </div>

--- a/src/components/DatabaseStatusPanel.tsx
+++ b/src/components/DatabaseStatusPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Database as DatabaseIcon, CheckCircle, XCircle, RefreshCw, AlertCircle } from 'lucide-react';
+import { CheckCircle, XCircle, RefreshCw, AlertCircle } from 'lucide-react';
 import { testSupabaseConnection } from '../services/supabaseService';
 
 export default function DatabaseStatusPanel() {
@@ -39,21 +39,30 @@ export default function DatabaseStatusPanel() {
 
   return (
     <div className="bg-white rounded-lg shadow-md p-6 border border-gray-200 space-y-4">
-      <div className="flex items-center space-x-3">
-        <DatabaseIcon className="h-6 w-6" style={{ color: '#F29400' }} />
+      <div className="flex justify-between items-center mb-2">
+        <h2 className="text-lg font-semibold">Datenbankstatus</h2>
+        <div className="flex gap-2">
+          <button
+            onClick={handleTest}
+            disabled={status === 'loading'}
+            className="px-3 py-2 text-white rounded-md disabled:opacity-50"
+            style={{ backgroundColor: '#F29400' }}
+          >
+            Supabase testen
+          </button>
+          <button
+            onClick={handleTest}
+            disabled={status === 'loading'}
+            className="px-3 py-2 border border-gray-300 rounded-md text-sm disabled:opacity-50"
+          >
+            Aktualisieren
+          </button>
+        </div>
       </div>
       <div className="flex items-center space-x-2">
         {renderIcon()}
         {message && <span className="text-sm">{message}</span>}
       </div>
-      <button
-        onClick={handleTest}
-        disabled={status === 'loading'}
-        className="px-3 py-2 text-white rounded-md disabled:opacity-50"
-        style={{ backgroundColor: '#F29400' }}
-      >
-        Verbindung testen
-      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace database icon with text heading in DatabaseStatus component
- show the same header in DatabaseStatusPanel

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686e1de2e26c832583b44414f91becd5