### PR TITLE
Update layout and remove width limits

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,8 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { User, Briefcase, Sparkles, AlertTriangle, Settings } from 'lucide-react';
-import { Routes, Route, useNavigate } from 'react-router-dom';
-import InputSection from './components/InputSection';
-import CoverLetterDisplay from './components/CoverLetterDisplay';
-import StyleSelector from './components/StyleSelector';
-import DocumentTypeSelector from './components/DocumentTypeSelector';
+import { Routes, Route } from 'react-router-dom';
+import Sidebar from './components/Sidebar';
+import ProfileInput from './components/ProfileInput';
+import JobInputAndPreview from './components/JobInputAndPreview';
 import SettingsPage from './components/SettingsPage';
 import { generateCoverLetter, editCoverLetter } from './services/mistralService';
 import 'react-quill/dist/quill.snow.css';
@@ -261,7 +259,6 @@ function saveToStorage<T>(key: string, value: T): void {
 }
 
 function HomePage() {
-  const navigate = useNavigate();
   const [cvContent, setCvContent] = useState('');
   const [jobContent, setJobContent] = useState('');
   const [coverLetter, setCoverLetter] = useState('');
@@ -468,131 +465,38 @@ function HomePage() {
 
 
   return (
-    <div className="min-h-screen bg-white">
-      <div className="container mx-auto px-4 py-8 max-w-7xl">
-        {/* BOLT-UI-ANPASSUNG 2025-01-15: Header - Titel und Icon linksbündig, Header kleiner */}
-        <div className="relative mb-8">
-          {/* BOLT-UI-ANPASSUNG 2025-01-15: Nur Zahnradsymbol oben rechts */}
-          <div className="absolute top-0 right-0">
-            <button
-              onClick={() => navigate('/settings')}
-              className="flex items-center p-2 bg-white rounded-lg shadow-sm border hover:bg-gray-50 transition-colors duration-200"
-              title="App-Konfiguration öffnen"
-            >
-              <Settings className="h-5 w-5 text-gray-500" />
-            </button>
-          </div>
-          
-          {/* BOLT-UI-ANPASSUNG 2025-01-15: Titel und Logo linksbündig und kleiner */}
-          <div className="flex items-center space-x-3 mb-4">
-            <div className="bg-orange-500 p-2 rounded-xl shadow-lg" style={{ backgroundColor: '#F29400' }}>
-              <Sparkles className="h-6 w-6 text-white" />
-            </div>
-            <h1 className="text-2xl font-bold text-gray-900">
-              Bewerbungsschreiben Generator
-            </h1>
-          </div>
-        </div>
-
-        {/* Document Type Selector */}
-        <DocumentTypeSelector
-          documentTypes={documentTypes}
-          selectedType={selectedDocumentType}
-          onTypeChange={setSelectedDocumentType}
-        />
-
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
-          {/* CV Input */}
-          <InputSection
-            title="Lebenslauf / Profil"
-            icon={<User className="h-6 w-6 text-orange-600" />}
-            onContentChange={setCvContent}
-            placeholder="Geben Sie hier Ihre beruflichen Erfahrungen, Qualifikationen, Fähigkeiten und relevanten Informationen aus Ihrem Lebenslauf ein..."
-            isProfileSection={true}
-            profileConfig={profileConfig}
-          />
-
-          {/* Job Description Input */}
-          <InputSection
-            title="Stellenanzeige"
-            icon={<Briefcase className="h-6 w-6 text-orange-600" />}
-            onContentChange={setJobContent}
-            placeholder="Fügen Sie hier die Stellenanzeige ein, einschließlich Anforderungen, Aufgaben und Unternehmensinfos..."
-            showUrlInput={true}
-            profileConfig={profileConfig}
-          />
-        </div>
-
-        {/* Style Selector */}
-        <StyleSelector
-          selectedStyles={selectedStyles}
-          onStylesChange={setSelectedStyles}
-          stylePrompts={stylePrompts}
-        />
-
-        {/* Generate Button */}
-        <div className="flex justify-center mb-8">
-          <button
-            onClick={handleGenerate}
-            disabled={isGenerating || !cvContent.trim() || !jobContent.trim()}
-            className="flex items-center space-x-3 px-8 py-4 text-white font-semibold rounded-xl disabled:opacity-50 disabled:cursor-not-allowed transform hover:scale-105 transition-all duration-200 shadow-lg"
-            style={{ 
-              backgroundColor: '#F29400',
-              ':hover': { backgroundColor: '#E8850C' }
-            } as React.CSSProperties}
-          >
-            {/* BOLT-UI-ANPASSUNG 2025-01-15: Animation beim Generieren */}
-            {isGenerating ? (
-              <>
-                <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
-                <span className="text-lg">Wird generiert...</span>
-              </>
-            ) : (
-              <>
-                <Sparkles className="h-5 w-5" />
-                <span className="text-lg">Bewerbungsschreiben generieren</span>
-              </>
-            )}
-          </button>
-        </div>
-
-        {/* Error Display */}
-        {error && (
-          <div className="mb-8 bg-red-50 border border-red-200 rounded-lg p-4">
-            <div className="flex items-center space-x-2 text-red-700">
-              <AlertTriangle className="h-5 w-5 flex-shrink-0" />
-              <p className="font-medium">{error}</p>
-            </div>
-          </div>
-        )}
-
-
-        {/* Cover Letter Display */}
-        <CoverLetterDisplay
-          content={coverLetter}
-          isLoading={isGenerating}
-          isEditing={isEditing}
-          onEdit={handleEdit}
-          onContentChange={handleDirectContentChange}
-          editPrompts={editPrompts}
-        />
-
-        {/* Footer */}
-        <div className="mt-12 text-center">
-          <p className="text-gray-500">
-            Powered by Mistral AI • Quill Editor
-            {isSupabaseConfigured() && (
-              <span className="ml-2">• Profil-Daten von Supabase</span>
-            )}
-            {profileSourceMappings.length > 0 && (
-              <span className="ml-2">• {profileSourceMappings.filter(m => m.isActive).length} aktive Datenquellen</span>
-            )}
-            {databaseStats && databaseStats.totalFromMappings > 0 && (
-              <span className="ml-2">• {databaseStats.totalFromMappings.toLocaleString('de-DE')} Mapping-Einträge</span>
-            )}
-          </p>
-        </div>
-      </div>
+    <div className="grid grid-cols-[22%_40%_38%] gap-4 p-4 max-w-none w-full h-screen">
+      <Sidebar
+        className="col-span-1"
+        documentTypes={documentTypes}
+        selectedType={selectedDocumentType}
+        onTypeChange={setSelectedDocumentType}
+      />
+      <ProfileInput
+        className="col-span-1"
+        onContentChange={setCvContent}
+        profileConfig={profileConfig}
+      />
+      <JobInputAndPreview
+        className="col-span-1"
+        jobContent={jobContent}
+        onJobContentChange={setJobContent}
+        onGenerate={handleGenerate}
+        isGenerating={isGenerating}
+        cvContent={cvContent}
+        coverLetter={coverLetter}
+        isEditing={isEditing}
+        onEdit={handleEdit}
+        onContentChange={handleDirectContentChange}
+        editPrompts={editPrompts}
+        selectedStyles={selectedStyles}
+        onStylesChange={setSelectedStyles}
+        stylePrompts={stylePrompts}
+        error={error}
+        profileConfig={profileConfig}
+        profileSourceMappings={profileSourceMappings}
+        databaseStats={databaseStats}
+      />
     </div>
   );
 }

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -2,15 +2,15 @@
 
 import React from 'react';
 import Sidebar from './Sidebar';
-import ProfileEditor from './ProfileEditor';
-import JobInputPanel from './JobInputPanel';
+import ProfileInput from './ProfileInput';
+import JobInputAndPreview from './JobInputAndPreview';
 
 export default function AppLayout() {
   return (
-    <div className="grid grid-cols-[22%_1fr_32%] gap-4 p-4 max-w-full min-h-screen">
+    <div className="grid grid-cols-[22%_40%_38%] gap-4 p-4 max-w-none w-full h-screen">
       <Sidebar className="col-span-1" />
-      <ProfileEditor className="col-span-1" />
-      <JobInputPanel className="col-span-1" />
+      <ProfileInput className="col-span-1" />
+      <JobInputAndPreview className="col-span-1" />
     </div>
   );
 }

--- a/src/components/JobInputAndPreview.tsx
+++ b/src/components/JobInputAndPreview.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { Briefcase, Sparkles, AlertTriangle } from 'lucide-react';
+import InputSection from './InputSection';
+import StyleSelector from './StyleSelector';
+import CoverLetterDisplay from './CoverLetterDisplay';
+import { ProfileConfig, ProfileSourceMapping, DatabaseStats, isSupabaseConfigured } from '../services/supabaseService';
+
+interface JobInputAndPreviewProps {
+  className?: string;
+  jobContent: string;
+  onJobContentChange: (content: string) => void;
+  onGenerate: () => void;
+  isGenerating: boolean;
+  cvContent: string;
+  coverLetter: string;
+  isEditing: boolean;
+  onEdit: (instruction: string) => void;
+  onContentChange: (content: string) => void;
+  editPrompts: {
+    [key: string]: { label: string; prompt: string };
+  };
+  selectedStyles: string[];
+  onStylesChange: (styles: string[]) => void;
+  stylePrompts: {
+    [key: string]: { label: string; prompt: string };
+  };
+  error: string;
+  profileConfig: ProfileConfig;
+  profileSourceMappings: ProfileSourceMapping[];
+  databaseStats: DatabaseStats | null;
+}
+
+export default function JobInputAndPreview({
+  className = '',
+  jobContent,
+  onJobContentChange,
+  onGenerate,
+  isGenerating,
+  cvContent,
+  coverLetter,
+  isEditing,
+  onEdit,
+  onContentChange,
+  editPrompts,
+  selectedStyles,
+  onStylesChange,
+  stylePrompts,
+  error,
+  profileConfig,
+  profileSourceMappings,
+  databaseStats,
+}: JobInputAndPreviewProps) {
+  return (
+    <div className={className}>
+      <InputSection
+        title="Stellenanzeige"
+        icon={<Briefcase className="h-6 w-6 text-orange-600" />}
+        onContentChange={onJobContentChange}
+        placeholder="F\u00fcgen Sie hier die Stellenanzeige ein, einschlie\u00dflich Anforderungen, Aufgaben und Unternehmensinfos..."
+        showUrlInput={true}
+        profileConfig={profileConfig}
+      />
+
+      <StyleSelector
+        selectedStyles={selectedStyles}
+        onStylesChange={onStylesChange}
+        stylePrompts={stylePrompts}
+      />
+
+      <div className="flex justify-center mb-8">
+        <button
+          onClick={onGenerate}
+          disabled={isGenerating || !cvContent.trim() || !jobContent.trim()}
+          className="flex items-center space-x-3 px-8 py-4 text-white font-semibold rounded-xl disabled:opacity-50 disabled:cursor-not-allowed transform hover:scale-105 transition-all duration-200 shadow-lg"
+          style={{ backgroundColor: '#F29400' }}
+        >
+          {isGenerating ? (
+            <>
+              <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
+              <span className="text-lg">Wird generiert...</span>
+            </>
+          ) : (
+            <>
+              <Sparkles className="h-5 w-5" />
+              <span className="text-lg">Bewerbungsschreiben generieren</span>
+            </>
+          )}
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-8 bg-red-50 border border-red-200 rounded-lg p-4">
+          <div className="flex items-center space-x-2 text-red-700">
+            <AlertTriangle className="h-5 w-5 flex-shrink-0" />
+            <p className="font-medium">{error}</p>
+          </div>
+        </div>
+      )}
+
+      <CoverLetterDisplay
+        content={coverLetter}
+        isLoading={isGenerating}
+        isEditing={isEditing}
+        onEdit={onEdit}
+        onContentChange={onContentChange}
+        editPrompts={editPrompts}
+      />
+
+      <div className="mt-12 text-center">
+        <p className="text-gray-500">
+          Powered by Mistral AI \u2022 Quill Editor
+          {isSupabaseConfigured() && (
+            <span className="ml-2">\u2022 Profil-Daten von Supabase</span>
+          )}
+          {profileSourceMappings.length > 0 && (
+            <span className="ml-2">\u2022 {profileSourceMappings.filter(m => m.isActive).length} aktive Datenquellen</span>
+          )}
+          {databaseStats && databaseStats.totalFromMappings > 0 && (
+            <span className="ml-2">\u2022 {databaseStats.totalFromMappings.toLocaleString('de-DE')} Mapping-Eintr\u00e4ge</span>
+          )}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/KIModelSettingsItem.tsx
+++ b/src/components/KIModelSettingsItem.tsx
@@ -14,7 +14,6 @@ import StyledButton from './StyledButton';
 
 interface KIModelSettingsItemProps {
   model: KIModelSettings;
-  index: number;
   handleModelField: (
     id: string,
     field: keyof KIModelSettings,
@@ -53,13 +52,11 @@ const ENDPOINT_MAP: Record<string, string> = {
 
 function KIModelSettingsItem({
   model,
-  index,
   handleModelField,
   handleModelSelection,
   setActiveModel,
   removeModel
 }: KIModelSettingsItemProps) {
-  const [testState, setTestState] = useState<'untested' | 'success' | 'error'>('untested');
   const [isTesting, setIsTesting] = useState(false);
 
   const onModelChange = useCallback(
@@ -104,12 +101,6 @@ function KIModelSettingsItem({
     }
   }, [model]);
 
-  const statusColor =
-    testState === 'success'
-      ? 'bg-green-500'
-      : testState === 'error'
-      ? 'bg-red-500'
-      : 'bg-yellow-500';
 
   return (
     <Accordion>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -296,7 +296,7 @@ export default function SettingsPage() {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-6xl max-h-[95vh] flex flex-col overflow-hidden">
+      <div className="bg-white rounded-lg shadow-xl w-full max-h-[95vh] flex flex-col overflow-hidden">
         <div className="flex items-center justify-between p-6 border-b border-gray-200">
           <div className="flex items-center space-x-3">
             <SettingsIcon className="h-6 w-6" style={{ color: '#F29400' }} />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import DocumentTypeSelector from './DocumentTypeSelector';
+
+interface SidebarProps {
+  className?: string;
+  documentTypes: {
+    [key: string]: {
+      label: string;
+      prompt: string;
+    };
+  };
+  selectedType: string;
+  onTypeChange: (type: string) => void;
+}
+
+export default function Sidebar({
+  className = '',
+  documentTypes,
+  selectedType,
+  onTypeChange,
+}: SidebarProps) {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div className={className}>
+      <button
+        onClick={() => setOpen(!open)}
+        className="mb-2 text-sm text-gray-700"
+      >
+        {open ? '▾ Dokument-Typ' : '▸ Dokument-Typ'}
+      </button>
+      {open && (
+        <DocumentTypeSelector
+          documentTypes={documentTypes}
+          selectedType={selectedType}
+          onTypeChange={onTypeChange}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/TemplateManagerModal.tsx
+++ b/src/components/TemplateManagerModal.tsx
@@ -159,7 +159,7 @@ export default function TemplateManagerModal({
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-6xl max-h-[95vh] flex flex-col overflow-hidden">
+      <div className="bg-white rounded-lg shadow-xl w-full max-h-[95vh] flex flex-col overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b border-gray-200 flex-shrink-0">
           <div className="flex items-center space-x-3">
@@ -298,7 +298,7 @@ export default function TemplateManagerModal({
         {/* New Template Form Modal */}
         {showNewTemplateForm && (
           <div className="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4">
-            <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col">
+            <div className="bg-white rounded-lg shadow-xl w-full max-h-[90vh] flex flex-col">
               <div className="flex items-center justify-between p-6 border-b border-gray-200">
                 <h3 className="text-lg font-semibold text-gray-900">Neue Vorlage erstellen</h3>
                 <button
@@ -365,7 +365,7 @@ export default function TemplateManagerModal({
         {/* Edit Template Modal */}
         {editingTemplate && (
           <div className="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4">
-            <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col">
+            <div className="bg-white rounded-lg shadow-xl w-full max-h-[90vh] flex flex-col">
               <div className="flex items-center justify-between p-6 border-b border-gray-200">
                 <h3 className="text-lg font-semibold text-gray-900">Vorlage bearbeiten</h3>
                 <button


### PR DESCRIPTION
## Summary
- implement new grid layout using `Sidebar`, `ProfileInput` and `JobInputAndPreview`
- remove all `max-w-*` constraints from settings and template modals
- add Sidebar component with collapsible document type selector
- add JobInputAndPreview component for job input, style options and preview
- clean up unused props in `KIModelSettingsItem`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686e2ab95e5483258add5a783d8a2bd4