### PR TITLE
Improve desktop layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -465,20 +465,24 @@ function HomePage() {
 
 
   return (
-    <div className="grid grid-cols-[22%_40%_38%] gap-4 p-4 max-w-none w-full h-screen">
-      <Sidebar
-        className="col-span-1"
-        documentTypes={documentTypes}
-        selectedType={selectedDocumentType}
-        onTypeChange={setSelectedDocumentType}
-      />
-      <ProfileInput
-        className="col-span-1"
-        onContentChange={setCvContent}
-        profileConfig={profileConfig}
-      />
-      <JobInputAndPreview
-        className="col-span-1"
+    <div className="h-screen w-screen overflow-hidden flex flex-col">
+      <header className="sticky top-0 z-20 bg-white shadow-md py-4">
+        <h1 className="text-2xl font-bold text-center">Bewerbungsschreiben Generator</h1>
+      </header>
+      <div className="grid grid-cols-[22%_40%_38%] gap-4 flex-1 overflow-hidden">
+        <Sidebar
+          className="col-span-1 h-full overflow-y-auto"
+          documentTypes={documentTypes}
+          selectedType={selectedDocumentType}
+          onTypeChange={setSelectedDocumentType}
+        />
+        <ProfileInput
+          className="col-span-1 h-full overflow-y-auto"
+          onContentChange={setCvContent}
+          profileConfig={profileConfig}
+        />
+        <JobInputAndPreview
+          className="col-span-1 h-full overflow-y-auto"
         jobContent={jobContent}
         onJobContentChange={setJobContent}
         onGenerate={handleGenerate}
@@ -497,6 +501,7 @@ function HomePage() {
         profileSourceMappings={profileSourceMappings}
         databaseStats={databaseStats}
       />
+      </div>
     </div>
   );
 }

--- a/src/components/DocumentTypeSelector.tsx
+++ b/src/components/DocumentTypeSelector.tsx
@@ -26,7 +26,7 @@ export default function DocumentTypeSelector({ documentTypes, selectedType, onTy
   const typeEntries = Object.entries(documentTypes);
 
   return (
-    <div className="bg-white rounded-lg shadow-md p-6 mb-8 border border-gray-200">
+    <div className="bg-white rounded-lg shadow-md p-6 mb-8 border border-gray-200 sticky top-0 z-10">
       <div className="flex items-center space-x-3 mb-4">
         <FileText className="h-6 w-6" style={{ color: '#F29400' }} />
         {/* BOLT-UI-ANPASSUNG 2025-01-15: Titel geändert */}
@@ -35,7 +35,7 @@ export default function DocumentTypeSelector({ documentTypes, selectedType, onTy
       
       <fieldset>
         <legend className="sr-only">Dokumenttyp auswählen</legend>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div className="flex flex-col space-y-4">
           {typeEntries.map(([typeKey, typeData]) => {
             const IconComponent = ICON_MAP[typeKey] || FileText;
             const isSelected = selectedType === typeKey;

--- a/src/components/InputSection.tsx
+++ b/src/components/InputSection.tsx
@@ -94,14 +94,15 @@ export default function InputSection({
   const isJobSection = title.toLowerCase().includes('stellenanzeige');
 
   return (
-    <div className="bg-white rounded-lg shadow-md p-6">
-      <div className="flex items-center space-x-3 mb-6">
-        {/* BOLT-UI-ANPASSUNG 2025-01-15: Icons in #F29400 einfärben */}
-        {React.cloneElement(icon as React.ReactElement, { style: { color: '#F29400' } })}
-        <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
-      </div>
+    <div className="bg-white rounded-lg shadow-md p-6 h-full flex flex-col overflow-y-auto">
+      <div className="sticky top-0 bg-white pb-4 z-10">
+        <div className="flex items-center space-x-3 mb-6">
+          {/* BOLT-UI-ANPASSUNG 2025-01-15: Icons in #F29400 einfärben */}
+          {React.cloneElement(icon as React.ReactElement, { style: { color: '#F29400' } })}
+          <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
+        </div>
 
-      <div className="flex space-x-1 mb-6 bg-gray-100 p-1 rounded-lg">
+        <div className="flex space-x-1 mb-6 bg-gray-100 p-1 rounded-lg">
         {isProfileSection && (
           <>
             <button
@@ -192,6 +193,7 @@ export default function InputSection({
             <span>URL</span>
           </button>
         )}
+      </div>
       </div>
 
       {mode === 'structured' && isProfileSection && (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -22,7 +22,7 @@ export default function Sidebar({
   const [open, setOpen] = useState(true);
 
   return (
-    <div className={className}>
+    <div className={`${className} overflow-y-auto`}>
       <button
         onClick={() => setOpen(!open)}
         className="mb-2 text-sm text-gray-700"


### PR DESCRIPTION
## Summary
- make document type list vertical and sticky
- keep title and section tabs visible while scrolling
- adjust grid layout and scrolling columns for better desktop usage

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686e2f301a4483258d8e1c66bc8553fd