### PR TITLE
Improve generator layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -469,7 +469,7 @@ function HomePage() {
       <header className="sticky top-0 z-20 bg-white shadow-md py-4">
         <h1 className="text-2xl font-bold text-center">Bewerbungsschreiben Generator</h1>
       </header>
-      <div className="grid grid-cols-[22%_40%_38%] gap-4 flex-1 overflow-hidden">
+      <div className="grid grid-cols-[260px_1fr_1fr] gap-4 w-full px-4 flex-1 overflow-hidden">
         <Sidebar
           className="col-span-1 h-full overflow-y-auto"
           documentTypes={documentTypes}

--- a/src/components/DocumentTypeSelector.tsx
+++ b/src/components/DocumentTypeSelector.tsx
@@ -35,7 +35,7 @@ export default function DocumentTypeSelector({ documentTypes, selectedType, onTy
       
       <fieldset>
         <legend className="sr-only">Dokumenttyp auswählen</legend>
-        <div className="flex flex-col space-y-4">
+        <div className="flex flex-col space-y-2">
           {typeEntries.map(([typeKey, typeData]) => {
             const IconComponent = ICON_MAP[typeKey] || FileText;
             const isSelected = selectedType === typeKey;
@@ -53,10 +53,10 @@ export default function DocumentTypeSelector({ documentTypes, selectedType, onTy
                   className="sr-only"
                 />
                 <div
-                  className={`flex items-center space-x-3 px-6 py-4 rounded-lg font-medium transition-all duration-200 border-2 text-left ${
-                    isSelected
-                      ? 'text-white border-transparent shadow-md'
-                      : 'bg-white border-gray-300 text-gray-700 hover:border-orange-300 hover:bg-orange-50'
+                  className={`flex items-center space-x-3 px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 border-2 text-left ${
+                      isSelected
+                        ? 'text-white border-transparent shadow-md'
+                        : 'bg-white border-gray-300 text-gray-700 hover:border-orange-300 hover:bg-orange-50'
                   }`}
                   style={isSelected ? { backgroundColor: '#F29400' } : {}}
                   title={`Klicken Sie hier, um "${typeData.label}" auszuwählen`}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import DocumentTypeSelector from './DocumentTypeSelector';
 
 interface SidebarProps {
@@ -19,23 +19,13 @@ export default function Sidebar({
   selectedType,
   onTypeChange,
 }: SidebarProps) {
-  const [open, setOpen] = useState(true);
-
   return (
     <div className={`${className} overflow-y-auto`}>
-      <button
-        onClick={() => setOpen(!open)}
-        className="mb-2 text-sm text-gray-700"
-      >
-        {open ? '▾ Dokument-Typ' : '▸ Dokument-Typ'}
-      </button>
-      {open && (
-        <DocumentTypeSelector
-          documentTypes={documentTypes}
-          selectedType={selectedType}
-          onTypeChange={onTypeChange}
-        />
-      )}
+      <DocumentTypeSelector
+        documentTypes={documentTypes}
+        selectedType={selectedType}
+        onTypeChange={onTypeChange}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- adjust DocumentType selector styles for smaller buttons
- remove collapsible sidebar behavior so document types stay visible
- change main layout to a 3-column grid with fixed sidebar width

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e3586884c8325aab15a22b18600b5