### PR TITLE
Add Lebenslauf placeholder component

### DIFF
--- a/src/Home.vue
+++ b/src/Home.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { ref } from 'vue';
+import LebenslaufPlaceholder from '@/components/LebenslaufPlaceholder.vue';
+
+// Beispiel: aktive Registerkarte ("bewerbung" oder "lebenslauf")
+const activeTab = ref('bewerbung');
+</script>
+
+<template>
+  <div>
+    <div class="mb-4 space-x-2">
+      <button @click="activeTab = 'bewerbung'" class="px-4 py-2 bg-gray-200 rounded">Bewerbung</button>
+      <button @click="activeTab = 'lebenslauf'" class="px-4 py-2 bg-gray-200 rounded">Lebenslauf</button>
+    </div>
+
+    <div v-if="activeTab === 'lebenslauf'">
+      <LebenslaufPlaceholder />
+    </div>
+  </div>
+</template>

--- a/src/components/LebenslaufPlaceholder.vue
+++ b/src/components/LebenslaufPlaceholder.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="text-center text-gray-500 p-10 border border-dashed border-orange-300 rounded-xl bg-orange-50">
+    <h2 class="text-xl font-semibold text-orange-600 mb-2">🚧 Lebenslauf-Generator</h2>
+    <p>Hier wird künftig ein eigener Lebenslauf-Generator mit vielen Funktionen zur Verfügung stehen.</p>
+  </div>
+</template>
+
+<script setup>
+// Keine Logik notwendig
+</script>


### PR DESCRIPTION
## Summary
- add `LebenslaufPlaceholder.vue` as resume tab placeholder
- create `Home.vue` example view that displays the placeholder for the `lebenslauf` tab

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686eae1dfdd48325b08e9402b280bf6e