### PR TITLE
Add Lebenslauf editor preview

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import InputColumns from './components/layout/InputColumns';
 import DocumentTypeBlock from './components/layout/DocumentTypeBlock';
 import GenerateControls from './components/layout/GenerateControls';
 import EditorBlock from './components/layout/EditorBlock';
-import LebenslaufInput from './components/LebenslaufInput';
+import LebenslaufEditor from './components/LebenslaufEditor';
 import { generateCoverLetter, editCoverLetter } from './services/mistralService';
 import 'react-quill/dist/quill.snow.css';
 import {
@@ -535,7 +535,7 @@ function HomePage() {
 
         {activeTab === 'lebenslauf' && (
           <div className="p-6">
-            <LebenslaufInput />
+            <LebenslaufEditor />
           </div>
         )}
 

--- a/src/components/LebenslaufEditor.tsx
+++ b/src/components/LebenslaufEditor.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import LebenslaufInput from "./LebenslaufInput";
+import LebenslaufPreview from "./LebenslaufPreview";
+
+export default function LebenslaufEditor() {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      {/* Linke Spalte: Eingabe */}
+      <div className="bg-white p-6 rounded-lg shadow border border-gray-200">
+        <LebenslaufInput />
+      </div>
+
+      {/* Rechte Spalte: Vorschau */}
+      <div className="bg-white p-6 rounded-lg shadow border border-gray-200">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          📄 Vorschau
+        </h2>
+        <LebenslaufPreview />
+      </div>
+    </div>
+  );
+}

--- a/src/components/LebenslaufPreview.tsx
+++ b/src/components/LebenslaufPreview.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function LebenslaufPreview() {
+  return (
+    <div className="border border-dashed border-gray-300 rounded-lg p-4 bg-gray-50 text-gray-500 min-h-[300px]">
+      <p className="italic">Hier erscheint die Vorschau deines Lebenslaufs …</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add LebenslaufEditor component with preview panel
- add LebenslaufPreview component
- show LebenslaufEditor in the Lebenslauf tab

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686eca8ad2748325b04b212da3111536