### PR TITLE
Add Lebenslauf context integration

### DIFF
--- a/src/components/LebenslaufEditor.tsx
+++ b/src/components/LebenslaufEditor.tsx
@@ -1,22 +1,23 @@
 import React from "react";
+import { LebenslaufProvider } from "../context/LebenslaufContext";
 import LebenslaufInput from "./LebenslaufInput";
 import LebenslaufPreview from "./LebenslaufPreview";
 
 export default function LebenslaufEditor() {
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-      {/* Linke Spalte: Eingabe */}
-      <div className="bg-white p-6 rounded-lg shadow border border-gray-200">
-        <LebenslaufInput />
-      </div>
+    <LebenslaufProvider>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Linke Spalte: Eingabe */}
+        <div className="bg-white p-6 rounded-lg shadow border border-gray-200">
+          <LebenslaufInput />
+        </div>
 
-      {/* Rechte Spalte: Vorschau */}
-      <div className="bg-white p-6 rounded-lg shadow border border-gray-200">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">
-          📄 Vorschau
-        </h2>
-        <LebenslaufPreview />
+        {/* Rechte Spalte: Vorschau */}
+        <div className="bg-white p-6 rounded-lg shadow border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">📄 Vorschau</h2>
+          <LebenslaufPreview />
+        </div>
       </div>
-    </div>
+    </LebenslaufProvider>
   );
 }

--- a/src/context/LebenslaufContext.tsx
+++ b/src/context/LebenslaufContext.tsx
@@ -1,0 +1,53 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+export interface Erfahrung {
+  firma: string;
+  position: string;
+  zeitraum: string;
+  beschreibung: string;
+}
+
+export interface Ausbildung {
+  institution: string;
+  abschluss: string;
+  zeitraum: string;
+}
+
+export interface LebenslaufDaten {
+  erfahrungen: Erfahrung[];
+  ausbildung: Ausbildung[];
+  kompetenzen: string[];
+  zieltext: string;
+}
+
+interface LebenslaufContextType {
+  daten: LebenslaufDaten;
+  setDaten: React.Dispatch<React.SetStateAction<LebenslaufDaten>>;
+}
+
+const defaultDaten: LebenslaufDaten = {
+  erfahrungen: [],
+  ausbildung: [],
+  kompetenzen: [],
+  zieltext: '',
+};
+
+const LebenslaufContext = createContext<LebenslaufContextType | undefined>(undefined);
+
+export function LebenslaufProvider({ children }: { children: ReactNode }) {
+  const [daten, setDaten] = useState<LebenslaufDaten>(defaultDaten);
+
+  return (
+    <LebenslaufContext.Provider value={{ daten, setDaten }}>
+      {children}
+    </LebenslaufContext.Provider>
+  );
+}
+
+export function useLebenslaufData() {
+  const context = useContext(LebenslaufContext);
+  if (!context) {
+    throw new Error('useLebenslaufData muss innerhalb von LebenslaufProvider verwendet werden');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add a Lebenslauf context with provider and hook
- wrap the Lebenslauf editor with this provider

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ece79808c8325a8206b71cf151481