### PR TITLE
Implement TagSelectorWithFavorites component with optional add button

### DIFF
--- a/src/components/AutocompleteInput.tsx
+++ b/src/components/AutocompleteInput.tsx
@@ -12,6 +12,7 @@ interface AutocompleteInputProps {
   className?: string;
   buttonColor?: string;
   showFavoritesButton?: boolean;
+  showAddButton?: boolean;
   id?: string;
   label?: string;
 }
@@ -27,6 +28,7 @@ export default function AutocompleteInput({
   className = '',
   buttonColor = 'orange',
   showFavoritesButton = false,
+  showAddButton = true,
   id,
   label
 }: AutocompleteInputProps) {
@@ -283,19 +285,20 @@ export default function AutocompleteInput({
         )}
         
         {/* Add button */}
-        <button
-          id={addButtonId}
-          name={`add-${inputId}`}
-          onClick={() => onAdd()}
-          disabled={disabled || !value.trim()}
-          className={`px-3 py-2 text-white rounded-md disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-200 ${getButtonColorClasses()}`}
-          style={{ backgroundColor: '#F29400' }}
-          title="Hinzufügen"
-          aria-label="Hinzufügen"
-        >
-          <Plus className="h-4 w-4" />
-        </button>
+        {showAddButton && (
+          <button
+            id={addButtonId}
+            name={`add-${inputId}`}
+            onClick={() => onAdd()}
+            disabled={disabled || !value.trim()}
+            className={`px-3 py-2 text-white rounded-md disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-200 ${getButtonColorClasses()}`}
+            style={{ backgroundColor: '#F29400' }}
+            title="Hinzufügen"
+            aria-label="Hinzufügen"
+          >
+            <Plus className="h-4 w-4" />
+          </button>
+        )}
       </div>
     </div>
-  );
-}
+  );}

--- a/src/components/TagSelectorWithFavorites.tsx
+++ b/src/components/TagSelectorWithFavorites.tsx
@@ -83,6 +83,7 @@ export default function TagSelectorWithFavorites({
         placeholder="Hinzufügen..."
         buttonColor="orange"
         showFavoritesButton={allowCustom}
+        showAddButton={allowCustom}
         label={label}
       />
 


### PR DESCRIPTION
## Summary
- add `showAddButton` prop to `AutocompleteInput` for optional add button display
- hide the add button in `TagSelectorWithFavorites` when custom terms are disabled

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ed7d98c808325b4e0840dccbf9d5a