### PR TITLE
Add TagSelectorWithFavorites to Lebenslauf form

### DIFF
--- a/src/components/LebenslaufInput.tsx
+++ b/src/components/LebenslaufInput.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { useLebenslaufData } from '../context/LebenslaufContext';
+import TagSelectorWithFavorites from './TagSelectorWithFavorites';
 
 export default function LebenslaufInput() {
   const { daten, setDaten } = useLebenslaufData();
@@ -42,12 +43,18 @@ export default function LebenslaufInput() {
             value={erfahrung?.firma || ''}
             onChange={e => updateErfahrung('firma', e.target.value)}
           />
-          <input
-            type="text"
-            placeholder="Position"
-            className="w-full px-3 py-2 border rounded"
-            value={erfahrung?.position || ''}
-            onChange={e => updateErfahrung('position', e.target.value)}
+          <TagSelectorWithFavorites
+            label="Position"
+            value={erfahrung.position ? [erfahrung.position] : []}
+            onChange={(val) => updateErfahrung('position', val[0] || '')}
+            favoritenKey="positionFavoriten"
+            options={[
+              'Projektmanager',
+              'Buchhalter',
+              'Verkäufer',
+              'Teamleiter',
+            ]}
+            allowCustom={true}
           />
           <input
             type="text"


### PR DESCRIPTION
## Summary
- import `TagSelectorWithFavorites` and use it instead of the plain input for `Position` in `LebenslaufInput`
- configure favorite storage and option list

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ed9ea8d848325859a9eb904640a9f