### PR TITLE
Use optional chaining for position selector

### DIFF
--- a/src/components/LebenslaufInput.tsx
+++ b/src/components/LebenslaufInput.tsx
@@ -45,7 +45,7 @@ export default function LebenslaufInput() {
           />
           <TagSelectorWithFavorites
             label="Position"
-            value={erfahrung.position ? [erfahrung.position] : []}
+            value={erfahrung?.position ? [erfahrung.position] : []}
             onChange={(val) => updateErfahrung('position', val[0] || '')}
             favoritenKey="positionFavoriten"
             options={[


### PR DESCRIPTION
## Summary
- prevent errors when position experience entry is missing by using optional chaining

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686edfac1abc8325826e6bcc4e43d5b0