### PR TITLE
Fix ZeitraumPicker state handling

### DIFF
--- a/src/components/ZeitraumPicker.tsx
+++ b/src/components/ZeitraumPicker.tsx
@@ -35,6 +35,9 @@ export default function ZeitraumPicker({
     (_, i) => currentYear - i,
   );
 
+  console.log("startMonth", startMonth);
+  console.log("startYear", startYear);
+
   const updateField = (
     field: keyof Omit<ZeitraumPickerProps, "onChange">,
     value: number | boolean | null,
@@ -71,9 +74,7 @@ export default function ZeitraumPicker({
         break;
     }
 
-    if (data.startYear !== null && (data.isCurrent || data.endYear !== null)) {
-      onChange(data);
-    }
+    onChange(data);
   };
 
   return (


### PR DESCRIPTION
## Summary
- add temporary logging for startMonth/year
- update ZeitraumPicker to call onChange for every change

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686fc47110c08325bf2e0f53afbf8712