### PR TITLE
Implement new AufgabenbereichInput with favorites

### DIFF
--- a/src/components/AufgabenbereichInput.tsx
+++ b/src/components/AufgabenbereichInput.tsx
@@ -1,46 +1,57 @@
 import React, { useEffect, useState } from 'react';
-import { X, Pencil } from 'lucide-react';
-import { ReactSortable } from 'react-sortablejs';
+import { X, Pencil, Star, ChevronDown } from 'lucide-react';
 import AutocompleteInput from './AutocompleteInput';
 
 interface AufgabenbereichInputProps {
-  /** Aktuelle Liste der Aufgaben */
   value: string[];
-  /** Callback bei Änderungen */
-  onChange: (tasks: string[]) => void;
-  /** Optionale Vorschläge */
+  onChange: (neueListe: string[]) => void;
   vorschlaege?: string[];
-  /** Drag & Drop aktivieren */
-  enableReorder?: boolean;
+  favoriten?: string[];
 }
 
 export default function AufgabenbereichInput({
   value,
   onChange,
   vorschlaege = [],
-  enableReorder = false,
+  favoriten = [],
 }: AufgabenbereichInputProps) {
   const [inputValue, setInputValue] = useState('');
-  const [suggestions, setSuggestions] = useState<string[]>(vorschlaege);
   const [editIndex, setEditIndex] = useState<number | null>(null);
   const [editValue, setEditValue] = useState('');
+  const [favorites, setFavorites] = useState<string[]>(() => {
+    try {
+      const stored = localStorage.getItem('aufgabenFavoriten');
+      if (stored) {
+        return JSON.parse(stored) as string[];
+      }
+    } catch {
+      // ignore parse errors
+    }
+    return favoriten;
+  });
 
   useEffect(() => {
-    setSuggestions(vorschlaege);
-  }, [vorschlaege]);
+    try {
+      localStorage.setItem(
+        'aufgabenFavoriten',
+        JSON.stringify(favorites.slice(-10))
+      );
+    } catch {
+      // ignore
+    }
+  }, [favorites]);
+
+  const allOptions = Array.from(new Set(vorschlaege));
 
   const addTask = (task?: string) => {
     const t = (task ?? inputValue).trim();
-    if (!t) return;
-    if (!value.includes(t)) {
-      onChange([...value, t]);
-    }
+    if (!t || value.includes(t)) return;
+    onChange([...value, t]);
     setInputValue('');
   };
 
-  const removeTask = (index: number) => {
-    const newTasks = value.filter((_, i) => i !== index);
-    onChange(newTasks);
+  const removeTask = (task: string) => {
+    onChange(value.filter((t) => t !== task));
   };
 
   const startEdit = (index: number) => {
@@ -58,80 +69,179 @@ export default function AufgabenbereichInput({
     setEditValue('');
   };
 
-  const suggestionButtons = suggestions
-    .filter((s) => !value.includes(s))
-    .map((s) => (
-      <button
-        key={s}
-        onClick={() => addTask(s)}
-        className="px-3 py-1 text-sm rounded-full border hover:bg-gray-100"
-        style={{ borderColor: '#F29400' }}
-      >
-        {s}
-      </button>
-    ));
+  const addToFavorites = (task: string) => {
+    if (!favorites.includes(task)) {
+      setFavorites([...favorites.slice(-9), task]);
+    }
+  };
 
-  const tasks = value.map((task, index) => (
-    <div
-      key={task}
-      className="inline-flex items-center px-3 py-1 text-sm rounded-full text-white mb-2 mr-2"
-      style={{ backgroundColor: '#F29400' }}
-    >
-      {editIndex === index ? (
-        <input
-          value={editValue}
-          onChange={(e) => setEditValue(e.target.value)}
-          onBlur={confirmEdit}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') confirmEdit();
-          }}
-          className="text-black px-1 py-0.5 rounded"
-          autoFocus
-        />
-      ) : (
-        <span className="mr-2">{task}</span>
-      )}
-      {editIndex !== index && (
-        <button
-          onClick={() => startEdit(index)}
-          className="mr-1 text-white hover:text-gray-200"
-          aria-label="Bearbeiten"
-        >
-          <Pencil className="h-3 w-3" />
-        </button>
-      )}
-      <button
-        onClick={() => removeTask(index)}
-        className="text-white hover:text-gray-200"
-        aria-label="Entfernen"
-      >
-        <X className="h-3 w-3" />
-      </button>
-    </div>
-  ));
+  const toggleFavorite = (task: string) => {
+    setFavorites(
+      favorites.includes(task)
+        ? favorites.filter((f) => f !== task)
+        : [...favorites.slice(-9), task]
+    );
+  };
 
   return (
     <div className="space-y-4">
+      <h3 className="text-sm font-medium text-gray-700">Aufgaben/Tätigkeiten</h3>
+
       <AutocompleteInput
         value={inputValue}
         onChange={setInputValue}
         onAdd={() => addTask()}
-        suggestions={suggestions}
+        onAddToFavorites={(val) => addToFavorites(val ?? inputValue)}
+        suggestions={allOptions}
         placeholder="Hinzufügen..."
         buttonColor="orange"
+        showFavoritesButton
       />
 
-      {suggestionButtons.length > 0 && (
-        <div className="flex flex-wrap gap-2">{suggestionButtons}</div>
+      {allOptions.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {allOptions.map((s) => (
+            <button
+              key={s}
+              onClick={() => addTask(s)}
+              className={`px-3 py-1 text-sm rounded-full border ${
+                value.includes(s) ? 'text-white' : 'hover:bg-gray-100'
+              }`}
+              style={
+                value.includes(s)
+                  ? { backgroundColor: '#F29400', borderColor: '#F29400' }
+                  : { borderColor: '#F29400' }
+              }
+            >
+              {s}
+            </button>
+          ))}
+        </div>
       )}
 
-      {enableReorder ? (
-        <ReactSortable list={[...value]} setList={onChange} className="flex flex-wrap">
-          {tasks}
-        </ReactSortable>
-      ) : (
-        <div className="flex flex-wrap">{tasks}</div>
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {value.map((task, index) => (
+            <div
+              key={`${task}-${index}`}
+              className="inline-flex items-center px-3 py-1 text-sm rounded-full text-white"
+              style={{ backgroundColor: '#F29400' }}
+            >
+              {editIndex === index ? (
+                <input
+                  value={editValue}
+                  onChange={(e) => setEditValue(e.target.value)}
+                  onBlur={confirmEdit}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') confirmEdit();
+                  }}
+                  className="text-black px-1 py-0.5 rounded"
+                  autoFocus
+                />
+              ) : (
+                <span className="mr-2">{task}</span>
+              )}
+              {editIndex !== index && (
+                <button
+                  onClick={() => startEdit(index)}
+                  className="mr-1 text-white hover:text-gray-200"
+                  aria-label="Bearbeiten"
+                >
+                  <Pencil className="h-3 w-3" />
+                </button>
+              )}
+              <button
+                onClick={() => removeTask(task)}
+                className="text-white hover:text-gray-200"
+                aria-label="Entfernen"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {favorites.filter((f) => !value.includes(f)).length > 0 && (
+        <div>
+          <div className="flex items-center space-x-2 mb-2">
+            <Star className="h-4 w-4 fill-current" style={{ color: '#F29400' }} />
+            <h4 className="text-sm font-medium text-gray-700">Favoriten:</h4>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {favorites
+              .filter((item) => !value.includes(item))
+              .map((item) => (
+                <button
+                  key={item}
+                  onClick={() => addTask(item)}
+                  className="inline-flex items-center justify-between px-3 py-1 text-gray-700 text-sm rounded-full border hover:bg-gray-200 transition-colors duration-200"
+                  style={{ backgroundColor: '#F3F4F6', borderColor: '#F29400' }}
+                >
+                  <span className="mr-2">{item}</span>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleFavorite(item);
+                    }}
+                    className="text-gray-600 hover:text-gray-800"
+                    aria-label={`${item} aus Favoriten entfernen`}
+                    title="Aus Favoriten entfernen"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </button>
+              ))}
+          </div>
+        </div>
+      )}
+
+      {allOptions.length > 0 && (
+        <details className="group">
+          <summary className="cursor-pointer text-sm font-medium text-gray-700 hover:text-gray-900 flex items-center space-x-2">
+            <span>Alle verfügbaren Optionen ({allOptions.length})</span>
+            <ChevronDown
+              className="h-4 w-4 group-open:rotate-180 transition-transform"
+              style={{ color: '#F29400' }}
+            />
+          </summary>
+          <div className="mt-3 space-y-3">
+            <div className="max-h-64 overflow-y-auto border border-gray-200 rounded-lg p-3 bg-gray-50">
+              <div className="flex flex-wrap gap-2">
+                {allOptions
+                  .filter((opt) => !value.includes(opt))
+                  .map((opt) => (
+                    <div key={opt} className="flex items-center space-x-1">
+                      <button
+                        onClick={() => addTask(opt)}
+                        className="inline-flex items-center justify-between px-3 py-1 bg-white text-gray-700 text-sm rounded-full transition-colors duration-200 border border-gray-300 hover:bg-gray-100"
+                      >
+                        <span className="mr-2">{opt}</span>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            toggleFavorite(opt);
+                          }}
+                          className={`transition-colors duration-200 ${favorites.includes(opt) ? 'hover:opacity-80' : 'text-gray-400 hover:opacity-80'}`}
+                          style={{ color: favorites.includes(opt) ? '#F29400' : undefined }}
+                          aria-label={
+                            favorites.includes(opt)
+                              ? `${opt} aus Favoriten entfernen`
+                              : `${opt} zu Favoriten hinzufügen`
+                          }
+                          title={favorites.includes(opt) ? 'Aus Favoriten entfernen' : 'Zu Favoriten hinzufügen'}
+                        >
+                          <Star className={`h-3 w-3 ${favorites.includes(opt) ? 'fill-current' : ''}`} />
+                        </button>
+                      </button>
+                    </div>
+                  ))}
+              </div>
+            </div>
+          </div>
+        </details>
       )}
     </div>
   );
 }
+

--- a/src/components/LebenslaufInput.tsx
+++ b/src/components/LebenslaufInput.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useMemo } from 'react';
 import TagSelectorWithFavorites from './TagSelectorWithFavorites';
 import ZeitraumPicker from './ZeitraumPicker';
 import AufgabenbereichInput from './AufgabenbereichInput';
+import { getTaskSuggestionsForBeruf } from '../constants/taskSuggestions';
 import {
   Berufserfahrung,
   useLebenslaufContext,
@@ -50,14 +51,8 @@ export default function LebenslaufInput() {
   };
 
   const aufgabenVorschlaege = useMemo(() => {
-    const mapping: Record<string, string[]> = {
-      Projektmanager: ['Projektkoordination', 'Teamleitung', 'Zeitplanung'],
-      Buchhalter: ['Finanzbuchhaltung', 'Kostenrechnung', 'Jahresabschlüsse'],
-      Verkäufer: ['Kundenberatung', 'Produktpräsentation', 'Verkaufsabschlüsse'],
-      Teamleiter: ['Mitarbeiterführung', 'Schichtplanung', 'Motivation'],
-    };
     const pos = form.position[0];
-    return pos && mapping[pos] ? mapping[pos] : [];
+    return pos ? getTaskSuggestionsForBeruf(pos) : [];
   }, [form.position]);
 
   const handleSubmit = () => {


### PR DESCRIPTION
## Summary
- enhance `AufgabenbereichInput` with title, favorites, and dropdown list of options
- use local task suggestion data in `LebenslaufInput`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6870112e502c8325b9c2d860a7e0c5d4