### PR TITLE
Handle multiple positions for task suggestions

### DIFF
--- a/src/components/AufgabenbereichInput.tsx
+++ b/src/components/AufgabenbereichInput.tsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { X, Pencil, Star, ChevronDown } from 'lucide-react';
 import AutocompleteInput from './AutocompleteInput';
+import { getTaskSuggestionsForBeruf } from '../constants/taskSuggestions';
 
 interface AufgabenbereichInputProps {
   value: string[];
   onChange: (neueListe: string[]) => void;
+  positionen: string[];
   vorschlaege?: string[];
   favoriten?: string[];
 }
@@ -12,6 +14,7 @@ interface AufgabenbereichInputProps {
 export default function AufgabenbereichInput({
   value,
   onChange,
+  positionen,
   vorschlaege = [],
   favoriten = [],
 }: AufgabenbereichInputProps) {
@@ -41,7 +44,15 @@ export default function AufgabenbereichInput({
     }
   }, [favorites]);
 
-  const allOptions = Array.from(new Set(vorschlaege));
+  const allOptions = useMemo(() => {
+    const fromPositions = positionen.flatMap((p) =>
+      getTaskSuggestionsForBeruf(p)
+    );
+    const combined = [...fromPositions, ...vorschlaege];
+    const unique = Array.from(new Set(combined));
+    unique.sort((a, b) => a.localeCompare(b, 'de', { sensitivity: 'base' }));
+    return unique;
+  }, [positionen, vorschlaege]);
 
   const addTask = (task?: string) => {
     const t = (task ?? inputValue).trim();

--- a/src/components/LebenslaufInput.tsx
+++ b/src/components/LebenslaufInput.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState } from 'react';
 import TagSelectorWithFavorites from './TagSelectorWithFavorites';
 import ZeitraumPicker from './ZeitraumPicker';
 import AufgabenbereichInput from './AufgabenbereichInput';
-import { getTaskSuggestionsForBeruf } from '../constants/taskSuggestions';
 import {
   Berufserfahrung,
   useLebenslaufContext,
@@ -50,11 +49,6 @@ export default function LebenslaufInput() {
     setForm(prev => ({ ...prev, [field]: value }));
   };
 
-  const aufgabenVorschlaege = useMemo(() => {
-    const pos = form.position[0];
-    return pos ? getTaskSuggestionsForBeruf(pos) : [];
-  }, [form.position]);
-
   const handleSubmit = () => {
     if (selectedExperienceId !== null) {
       updateExperience(selectedExperienceId, form);
@@ -65,11 +59,12 @@ export default function LebenslaufInput() {
     selectExperience(null);
   };
 
-
   return (
     <div className="space-y-8">
       <section>
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">💼 Berufserfahrung</h2>
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          💼 Berufserfahrung
+        </h2>
         <div className="border border-gray-300 rounded-lg p-4 bg-gray-50 space-y-2">
           <ZeitraumPicker
             value={{
@@ -88,7 +83,9 @@ export default function LebenslaufInput() {
               );
               updateField(
                 'startYear',
-                data.startYear !== undefined && data.startYear !== null ? String(data.startYear) : '',
+                data.startYear !== undefined && data.startYear !== null
+                  ? String(data.startYear)
+                  : '',
               );
               updateField(
                 'endMonth',
@@ -98,7 +95,9 @@ export default function LebenslaufInput() {
               );
               updateField(
                 'endYear',
-                data.endYear !== undefined && data.endYear !== null ? String(data.endYear) : null,
+                data.endYear !== undefined && data.endYear !== null
+                  ? String(data.endYear)
+                  : null,
               );
               updateField('isCurrent', data.isCurrent ?? false);
             }}
@@ -121,7 +120,7 @@ export default function LebenslaufInput() {
           <AufgabenbereichInput
             value={form.aufgabenbereiche}
             onChange={(val) => updateField('aufgabenbereiche', val)}
-            vorschlaege={aufgabenVorschlaege}
+            positionen={form.position}
           />
         </div>
         <button

--- a/src/constants/taskSuggestions.ts
+++ b/src/constants/taskSuggestions.ts
@@ -12,6 +12,7 @@ export const TASK_SUGGESTIONS: Record<string, string[]> = {
     'Budgetkontrolle',
     'Stakeholder-Kommunikation'
   ],
+  Techniker: ['Reparatur', 'Wartung', 'Ressourcenmanagement'],
   'Marketing Manager': [
     'Kampagnenplanung',
     'Marktanalysen',


### PR DESCRIPTION
## Summary
- add new prop `positionen` to `AufgabenbereichInput`
- collect task suggestions for all selected positions and merge them
- pass the positions from `LebenslaufInput`
- extend task suggestion list with a `Techniker` entry

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687014f13da08325ac5269091c5cbabe