### PR TITLE
Implement positions based task suggestions

### DIFF
--- a/src/components/AufgabenbereichInput.tsx
+++ b/src/components/AufgabenbereichInput.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { X, Pencil, Star } from 'lucide-react';
 import AutocompleteInput from './AutocompleteInput';
-import { getTaskSuggestionsForBeruf } from '../constants/taskSuggestions';
+import { getTasksForPositions } from '../constants/positionsToTasks';
 
 interface AufgabenbereichInputProps {
   value: string[];
@@ -45,9 +45,7 @@ export default function AufgabenbereichInput({
   }, [favorites]);
 
   const allOptions = useMemo(() => {
-    const fromPositions = positionen.flatMap((p) =>
-      getTaskSuggestionsForBeruf(p)
-    );
+    const fromPositions = getTasksForPositions(positionen);
     const combined = [...fromPositions, ...vorschlaege];
     const unique = Array.from(new Set(combined));
     unique.sort((a, b) => a.localeCompare(b, 'de', { sensitivity: 'base' }));
@@ -116,20 +114,39 @@ export default function AufgabenbereichInput({
       {gefilterteVorschlaege.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {gefilterteVorschlaege.map((s) => (
-            <button
-              key={s}
-              onClick={() => addTask(s)}
-              className={`px-3 py-1 text-sm rounded-full border ${
-                value.includes(s) ? 'text-white' : 'hover:bg-gray-100'
-              }`}
-              style={
-                value.includes(s)
-                  ? { backgroundColor: '#F29400', borderColor: '#F29400' }
-                  : { borderColor: '#F29400' }
-              }
-            >
-              {s}
-            </button>
+            <div key={s} className="flex items-center space-x-1">
+              <button
+                onClick={() => addTask(s)}
+                className={`px-3 py-1 text-sm rounded-full border ${
+                  value.includes(s) ? 'text-white' : 'hover:bg-gray-100'
+                }`}
+                style={
+                  value.includes(s)
+                    ? { backgroundColor: '#F29400', borderColor: '#F29400' }
+                    : { borderColor: '#F29400' }
+                }
+              >
+                {s}
+              </button>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggleFavorite(s);
+                }}
+                className={`transition-colors duration-200 ${
+                  favorites.includes(s) ? 'hover:opacity-80' : 'text-gray-400 hover:opacity-80'
+                }`}
+                style={{ color: favorites.includes(s) ? '#F29400' : undefined }}
+                aria-label={
+                  favorites.includes(s)
+                    ? `${s} aus Favoriten entfernen`
+                    : `${s} zu Favoriten hinzufügen`
+                }
+                title={favorites.includes(s) ? 'Aus Favoriten entfernen' : 'Zu Favoriten hinzufügen'}
+              >
+                <Star className={`h-3 w-3 ${favorites.includes(s) ? 'fill-current' : ''}`} />
+              </button>
+            </div>
           ))}
         </div>
       )}

--- a/src/components/LebenslaufInput.tsx
+++ b/src/components/LebenslaufInput.tsx
@@ -30,6 +30,7 @@ export default function LebenslaufInput() {
   } = useLebenslaufContext();
 
   const [form, setForm] = useState<BerufserfahrungForm>(initialExperience);
+  const [selectedPositions, setSelectedPositions] = useState<string[]>([]);
 
   useEffect(() => {
     if (selectedExperienceId !== null) {
@@ -39,9 +40,11 @@ export default function LebenslaufInput() {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { id, ...rest } = data;
         setForm(rest);
+        setSelectedPositions(rest.position);
       }
     } else {
       setForm(initialExperience);
+      setSelectedPositions([]);
     }
   }, [selectedExperienceId, berufserfahrungen]);
 
@@ -56,6 +59,7 @@ export default function LebenslaufInput() {
       addExperience(form);
     }
     setForm(initialExperience);
+    setSelectedPositions([]);
     selectExperience(null);
   };
 
@@ -111,8 +115,11 @@ export default function LebenslaufInput() {
           />
           <TagSelectorWithFavorites
             label="Positionen"
-            value={form.position}
-            onChange={val => updateField('position', val)}
+            value={selectedPositions}
+            onChange={(val) => {
+              setSelectedPositions(val);
+              updateField('position', val);
+            }}
             favoritenKey="positionFavoriten"
             options={['Projektmanager', 'Buchhalter', 'Verkäufer', 'Teamleiter']}
             allowCustom={true}
@@ -120,7 +127,7 @@ export default function LebenslaufInput() {
           <AufgabenbereichInput
             value={form.aufgabenbereiche}
             onChange={(val) => updateField('aufgabenbereiche', val)}
-            positionen={form.position}
+            positionen={selectedPositions}
           />
         </div>
         <button

--- a/src/constants/positionsToTasks.ts
+++ b/src/constants/positionsToTasks.ts
@@ -1,4 +1,4 @@
-export const TASK_SUGGESTIONS: Record<string, string[]> = {
+export const POSITIONS_TO_TASKS: Record<string, string[]> = {
   Softwareentwickler: [
     'Programmierung',
     'Code Review',
@@ -21,6 +21,11 @@ export const TASK_SUGGESTIONS: Record<string, string[]> = {
   ],
 };
 
-export function getTaskSuggestionsForBeruf(beruf: string): string[] {
-  return TASK_SUGGESTIONS[beruf] || [];
+export function getTasksForPosition(position: string): string[] {
+  return POSITIONS_TO_TASKS[position] || [];
+}
+
+export function getTasksForPositions(positions: string[]): string[] {
+  const tasks = positions.flatMap(p => getTasksForPosition(p));
+  return Array.from(new Set(tasks));
 }


### PR DESCRIPTION
## Summary
- add `positionsToTasks.ts` mapping
- extend `AufgabenbereichInput` to use new mapping and allow toggling favourites directly from suggestions
- manage selected positions state in `LebenslaufInput`
- update imports accordingly

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68701dfdb9ac8325b7d7849a3ed9eeec