### PR TITLE
fix: Favoritenstern zeigt Zustand korrekt (gefüllt vs. leer)

### DIFF
--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -133,11 +133,15 @@ export default function TasksTagInput({
                   <>
                     <button
                       onClick={() => toggleFavorite(task)}
-                      className={`star-icon ${favorites.includes(task) ? "active fill-current" : ""}`}
+                      className="star-icon"
                       aria-label="Favorit"
                       title="Favorit"
                     >
-                      <Star className="w-3 h-3" />
+                      <Star
+                        className="w-3 h-3"
+                        fill={favorites.includes(task) ? "#F29400" : "none"}
+                        stroke="#F29400"
+                      />
                     </button>
                     <button
                       onClick={() => startEdit(index)}
@@ -180,11 +184,15 @@ export default function TasksTagInput({
                     e.stopPropagation();
                     toggleFavorite(s);
                   }}
-                  className={`star-icon ${favorites.includes(s) ? "active fill-current" : ""}`}
+                  className="star-icon"
                   aria-label="Zu Favoriten"
                   title="Zu Favoriten"
                 >
-                  <Star className="w-3 h-3" />
+                  <Star
+                    className="w-3 h-3"
+                    fill={favorites.includes(s) ? "#F29400" : "none"}
+                    stroke="#F29400"
+                  />
                 </button>
               </button>
             ))}
@@ -214,11 +222,15 @@ export default function TasksTagInput({
                       e.stopPropagation();
                       toggleFavorite(item);
                     }}
-                    className="star-icon active fill-current"
+                    className="star-icon"
                     aria-label="Aus Favoriten entfernen"
                     title="Aus Favoriten entfernen"
                   >
-                    <Star className="w-3 h-3" />
+                    <Star
+                      className="w-3 h-3"
+                      fill={favorites.includes(item) ? "#F29400" : "none"}
+                      stroke="#F29400"
+                    />
                   </button>
                 </button>
               ))}

--- a/src/styles/Tags.css
+++ b/src/styles/Tags.css
@@ -36,12 +36,10 @@
 .tag .star-icon {
   display: inline-flex;
   margin-left: 0.25rem;
-  color: transparent;
-  transition: color 0.2s;
-}
-.tag .star-icon.active {
-  color: #f29400;
+  cursor: pointer;
+  transition: fill-opacity 0.2s;
+  fill-opacity: 1;
 }
 .tag .star-icon:hover {
-  color: #f7b24a;
+  fill-opacity: 0.8;
 }


### PR DESCRIPTION
## Summary
- update task favorite buttons to display filled/outlined star
- tweak star styles for hover and opacity

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

#codex #gpt

------
https://chatgpt.com/codex/tasks/task_e_6870b547cacc83258f02ae166d149f33