### PR TITLE
Fix star icon in Berufserfahrung favorites

### DIFF
--- a/src/components/TagSelectorWithFavorites.tsx
+++ b/src/components/TagSelectorWithFavorites.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { Star } from 'lucide-react';
 import AutocompleteInput from './AutocompleteInput';
 import PositionTag from './PositionTag';
 import TagButton from './TagButton';
@@ -80,7 +79,18 @@ export default function TagSelectorWithFavorites({
       {favorites.filter((f) => !value.includes(f)).length > 0 && (
         <div>
           <div className="flex items-center space-x-2 mb-2">
-            <Star className="h-4 w-4 fill-current" style={{ color: '#FDE047' }} />
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="#000000"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polygon points="12 2 15 8.5 22 9.3 17 14 18.2 21 12 17.8 5.8 21 7 14 2 9.3 9 8.5 12 2" />
+            </svg>
             <h4 className="text-sm font-medium text-gray-700">Favoriten:</h4>
           </div>
           <div className="flex flex-wrap gap-2">

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { Star, Lightbulb } from "lucide-react";
+import { Lightbulb } from "lucide-react";
 import TaskTag from "./TaskTag";
 import TagButton from "./TagButton";
 import AutocompleteInput from "./AutocompleteInput";
@@ -149,7 +149,18 @@ export default function TasksTagInput({
       {favorites.filter((f) => !value.includes(f)).length > 0 && (
         <div>
           <div className="flex items-center space-x-2 mb-2">
-            <Star className="h-4 w-4" style={{ color: "#FDE047" }} />
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="#000000"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polygon points="12 2 15 8.5 22 9.3 17 14 18.2 21 12 17.8 5.8 21 7 14 2 9.3 9 8.5 12 2" />
+            </svg>
             <h4 className="text-sm font-medium text-gray-700">Favoriten:</h4>
           </div>
           <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- use outline star SVG for favourites heading in position and tasks sections

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6870ceaefe6c8325b8903829682a5852