### PR TITLE
Update Experience form tags style

### DIFF
--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -22,10 +22,15 @@ export default function TagButton({
   const baseClasses =
     'rounded-full text-sm border flex items-center gap-1 px-3 py-1';
 
-  const variantClasses =
-    variant === 'selected'
-      ? 'bg-[#F29400] text-white border-[#F29400]'
-      : 'bg-white text-black border-[#F29400]';
+  let variantClasses = '';
+  if (variant === 'selected') {
+    variantClasses = 'bg-[#F29400] text-white border-[#F29400]';
+  } else if (variant === 'suggestion') {
+    variantClasses = 'bg-white text-gray-700 border-gray-300';
+  } else {
+    // favorite
+    variantClasses = 'bg-white text-gray-700 border-[#F29400]';
+  }
 
   const starStroke = variant === 'suggestion' ? '#F29400' : 'white';
   const starFill = variant === 'selected' && isFavorite ? '#FDE047' : 'none';

--- a/src/components/TagSelectorWithFavorites.tsx
+++ b/src/components/TagSelectorWithFavorites.tsx
@@ -66,13 +66,10 @@ export default function TagSelectorWithFavorites({
       />
 
       {value.length > 0 && (
-        <div>
-          <h4 className="text-sm font-medium text-gray-700 mb-2">Ausgewählt:</h4>
-          <div className="flex flex-wrap gap-2">
-            {value.map((tag) => (
-              <PositionTag key={tag} label={tag} onRemove={() => removeTag(tag)} />
-            ))}
-          </div>
+        <div className="flex flex-wrap gap-2">
+          {value.map((tag) => (
+            <PositionTag key={tag} label={tag} onRemove={() => removeTag(tag)} />
+          ))}
         </div>
       )}
 
@@ -84,12 +81,15 @@ export default function TagSelectorWithFavorites({
               height="16"
               viewBox="0 0 24 24"
               fill="none"
-              stroke="#000000"
+              stroke="#9CA3AF"
               strokeWidth="2"
               strokeLinecap="round"
               strokeLinejoin="round"
             >
-              <polygon points="12 2 15 8.5 22 9.3 17 14 18.2 21 12 17.8 5.8 21 7 14 2 9.3 9 8.5 12 2" />
+              <polygon
+                points="12 2 15 8.5 22 9.3 17 14 18.2 21 12 17.8 5.8 21 7 14 2 9.3 9 8.5 12 2"
+                fill="none"
+              />
             </svg>
             <h4 className="text-sm font-medium text-gray-700">Favoriten:</h4>
           </div>

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -86,11 +86,7 @@ export default function TasksTagInput({
       />
 
       {value.length > 0 && (
-        <div>
-          <h4 className="text-sm font-medium text-gray-700 mb-2">
-            Ausgewählt:
-          </h4>
-          <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-2">
             {value.map((task, index) => (
               editIndex === index ? (
                 <div key={`${task}-${index}`} className="tag">
@@ -122,7 +118,6 @@ export default function TasksTagInput({
               )
             ))}
           </div>
-        </div>
       )}
 
       {filteredSuggestions.length > 0 && (
@@ -154,12 +149,15 @@ export default function TasksTagInput({
               height="16"
               viewBox="0 0 24 24"
               fill="none"
-              stroke="#000000"
+              stroke="#9CA3AF"
               strokeWidth="2"
               strokeLinecap="round"
               strokeLinejoin="round"
             >
-              <polygon points="12 2 15 8.5 22 9.3 17 14 18.2 21 12 17.8 5.8 21 7 14 2 9.3 9 8.5 12 2" />
+              <polygon
+                points="12 2 15 8.5 22 9.3 17 14 18.2 21 12 17.8 5.8 21 7 14 2 9.3 9 8.5 12 2"
+                fill="none"
+              />
             </svg>
             <h4 className="text-sm font-medium text-gray-700">Favoriten:</h4>
           </div>


### PR DESCRIPTION
## Summary
- tweak TagButton styling for suggestion/favorite variants
- remove "Ausgewählt" headers from `TagSelectorWithFavorites` and `TasksTagInput`
- show grey outline star for favorites sections

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870d174718c8325a8a3b7688b3182b8