### PR TITLE
Fix favorite toggle for positions

### DIFF
--- a/src/components/PositionTag.tsx
+++ b/src/components/PositionTag.tsx
@@ -16,7 +16,8 @@ export default function PositionTag({ label, onRemove }: PositionTagProps) {
       label={label}
       variant="selected"
       isFavorite={isFavorite}
-      onToggleFavorite={() => toggleFavoritePosition(label)}
+      type="position"
+      onToggleFavorite={toggleFavoritePosition}
       onRemove={onRemove}
     />
   );

--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -4,7 +4,8 @@ interface TagButtonProps {
   label: string;
   isFavorite: boolean;
   variant: 'selected' | 'suggestion' | 'favorite';
-  onToggleFavorite?: () => void;
+  type?: string;
+  onToggleFavorite?: (label: string, type?: string) => void;
   onRemove?: () => void;
   onEdit?: () => void;
   onClick?: () => void;
@@ -14,6 +15,7 @@ export default function TagButton({
   label,
   isFavorite,
   variant,
+  type,
   onToggleFavorite,
   onRemove,
   onEdit,
@@ -37,7 +39,7 @@ export default function TagButton({
 
   const handleToggleFavorite = (e: React.MouseEvent) => {
     e.stopPropagation();
-    onToggleFavorite?.();
+    onToggleFavorite?.(label, type);
   };
 
   const handleRemove = (e: React.MouseEvent) => {

--- a/src/components/TagSelectorWithFavorites.tsx
+++ b/src/components/TagSelectorWithFavorites.tsx
@@ -102,6 +102,7 @@ export default function TagSelectorWithFavorites({
                   label={item}
                   variant="favorite"
                   isFavorite
+                  type="position"
                   onClick={() => addTag(item)}
                   onRemove={() => toggleFavorite(item)}
                 />

--- a/src/components/TaskTag.tsx
+++ b/src/components/TaskTag.tsx
@@ -17,7 +17,8 @@ export default function TaskTag({ label, onRemove, onEdit }: TaskTagProps) {
       label={label}
       variant="selected"
       isFavorite={isFavorite}
-      onToggleFavorite={() => toggleFavoriteTask(label)}
+      type="task"
+      onToggleFavorite={toggleFavoriteTask}
       onEdit={onEdit}
       onRemove={onRemove}
     />

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -134,7 +134,8 @@ export default function TasksTagInput({
                 variant="suggestion"
                 isFavorite={favorites.includes(s)}
                 onClick={() => addTask(s)}
-                onToggleFavorite={() => toggleFavorite(s)}
+                type="task"
+                onToggleFavorite={toggleFavorite}
               />
             ))}
           </div>
@@ -170,6 +171,7 @@ export default function TasksTagInput({
                   label={item}
                   variant="favorite"
                   isFavorite
+                  type="task"
                   onClick={() => addTask(item)}
                   onRemove={() => toggleFavorite(item)}
                 />


### PR DESCRIPTION
## Summary
- ensure TagButton passes label and type when toggling favorite
- update PositionTag and TaskTag to use new TagButton signature
- update TasksTagInput and TagSelectorWithFavorites accordingly

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870d53906f08325a0851381ad8d71c8