### PR TITLE
Fix TasksTagInput crash and improve tag editing UX

### DIFF
--- a/src/components/PositionTag.tsx
+++ b/src/components/PositionTag.tsx
@@ -5,9 +5,10 @@ import TagButton from './TagButton';
 interface PositionTagProps {
   label: string;
   onRemove: () => void;
+  onEdit?: () => void;
 }
 
-export default function PositionTag({ label, onRemove }: PositionTagProps) {
+export default function PositionTag({ label, onRemove, onEdit }: PositionTagProps) {
   const { favoritePositions, toggleFavoritePosition } = useLebenslaufContext();
   const isFavorite = favoritePositions.includes(label);
 
@@ -19,6 +20,7 @@ export default function PositionTag({ label, onRemove }: PositionTagProps) {
       type="position"
       onToggleFavorite={toggleFavoritePosition}
       onRemove={onRemove}
+      onEdit={onEdit}
     />
   );
 }

--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -1,4 +1,4 @@
-import { Star, Pencil, X } from 'lucide-react';
+import { Star, X } from 'lucide-react';
 
 interface TagButtonProps {
   label: string;
@@ -47,14 +47,16 @@ export default function TagButton({
     onRemove?.();
   };
 
-  const handleEdit = (e: React.MouseEvent) => {
+  const handleLabelClick = (e: React.MouseEvent) => {
+    if (!onEdit) return;
     e.stopPropagation();
-    onEdit?.();
+    onEdit();
   };
+
 
   return (
     <button type="button" onClick={onClick} className={`${baseClasses} ${variantClasses}`}>
-      <span>{label}</span>
+      <span onClick={variant === 'selected' ? handleLabelClick : undefined} className={onEdit ? 'cursor-text' : ''}>{label}</span>
       {variant !== 'favorite' && onToggleFavorite && (
         <span
           onClick={handleToggleFavorite}
@@ -65,16 +67,6 @@ export default function TagButton({
         >
           <Star className="w-3 h-3" stroke={starStroke} fill={starFill} />
         </span>
-      )}
-      {variant === 'selected' && onEdit && (
-        <button
-          type="button"
-          onClick={handleEdit}
-          className="ml-1"
-          aria-label="Bearbeiten"
-        >
-          <Pencil className="w-3 h-3" />
-        </button>
       )}
       {onRemove && (
         <button

--- a/src/components/TagSelectorWithFavorites.tsx
+++ b/src/components/TagSelectorWithFavorites.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { X } from 'lucide-react';
 import AutocompleteInput from './AutocompleteInput';
 import PositionTag from './PositionTag';
 import TagButton from './TagButton';
@@ -20,6 +21,8 @@ export default function TagSelectorWithFavorites({
   allowCustom,
 }: TagSelectorWithFavoritesProps) {
   const [inputValue, setInputValue] = useState('');
+  const [editIndex, setEditIndex] = useState<number | null>(null);
+  const [editValue, setEditValue] = useState('');
   const { favoritePositions: favorites, toggleFavoritePosition } = useLebenslaufContext();
 
 
@@ -50,6 +53,21 @@ export default function TagSelectorWithFavorites({
     }
   };
 
+  const startEdit = (index: number) => {
+    setEditIndex(index);
+    setEditValue(value[index]);
+  };
+
+  const confirmEdit = () => {
+    if (editIndex === null) return;
+    const trimmed = editValue.trim();
+    if (!trimmed) return;
+    const newTags = value.map((t, i) => (i === editIndex ? trimmed : t));
+    onChange(newTags);
+    setEditIndex(null);
+    setEditValue('');
+  };
+
   return (
     <div className="space-y-4">
       <AutocompleteInput
@@ -67,9 +85,36 @@ export default function TagSelectorWithFavorites({
 
       {value.length > 0 && (
         <div className="flex flex-wrap gap-2">
-          {value.map((tag) => (
-            <PositionTag key={tag} label={tag} onRemove={() => removeTag(tag)} />
-          ))}
+          {value.map((tag, index) =>
+            editIndex === index ? (
+              <div key={`${tag}-${index}`} className="tag">
+                <input
+                  value={editValue}
+                  onChange={(e) => setEditValue(e.target.value)}
+                  onBlur={confirmEdit}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') confirmEdit();
+                  }}
+                  className="text-black px-1 py-0.5 rounded"
+                  autoFocus
+                />
+                <button
+                  onClick={() => removeTag(tag)}
+                  className="tag-icon-button"
+                  aria-label="Entfernen"
+                >
+                  <X className="tag-icon" />
+                </button>
+              </div>
+            ) : (
+              <PositionTag
+                key={`${tag}-${index}`}
+                label={tag}
+                onRemove={() => removeTag(tag)}
+                onEdit={() => startEdit(index)}
+              />
+            )
+          )}
         </div>
       )}
 

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { Lightbulb } from "lucide-react";
+import { Lightbulb, X } from "lucide-react";
 import TaskTag from "./TaskTag";
 import TagButton from "./TagButton";
 import AutocompleteInput from "./AutocompleteInput";


### PR DESCRIPTION
## Summary
- import missing `X` icon in `TasksTagInput` to avoid runtime crash
- remove pencil icon from `TagButton`
- enable label click editing in `TagButton`
- extend `PositionTag` to support editing
- make position tags editable via `TagSelectorWithFavorites`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870d7ce860c8325983969781b4dee54