### PR TITLE
Update TagButton props and suggestion star fill

### DIFF
--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -2,7 +2,7 @@ import { Star, X } from 'lucide-react';
 
 interface TagButtonProps {
   label: string;
-  isFavorite: boolean;
+  isFavorite?: boolean;
   variant: 'selected' | 'suggestion' | 'favorite';
   type?: string;
   onToggleFavorite?: (label: string, type?: string) => void;
@@ -13,7 +13,7 @@ interface TagButtonProps {
 
 export default function TagButton({
   label,
-  isFavorite,
+  isFavorite = false,
   variant,
   type,
   onToggleFavorite,
@@ -35,7 +35,7 @@ export default function TagButton({
   }
 
   const starStroke = variant === 'suggestion' ? '#F29400' : 'white';
-  const starFill = variant === 'selected' && isFavorite ? '#FDE047' : 'none';
+  const starFill = isFavorite ? '#FDE047' : 'none';
 
   const handleToggleFavorite = (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -127,17 +127,20 @@ export default function TasksTagInput({
             Vorschläge:
           </h4>
           <div className="flex flex-wrap gap-2">
-            {filteredSuggestions.map((s) => (
-              <TagButton
-                key={s}
-                label={s}
-                variant="suggestion"
-                isFavorite={favorites.includes(s)}
-                onClick={() => addTask(s)}
-                type="task"
-                onToggleFavorite={toggleFavorite}
-              />
-            ))}
+            {filteredSuggestions.map((s) => {
+              const isFavorite = favorites.includes(s);
+              return (
+                <TagButton
+                  key={s}
+                  label={s}
+                  variant="suggestion"
+                  isFavorite={isFavorite}
+                  onClick={() => addTask(s)}
+                  type="task"
+                  onToggleFavorite={toggleFavorite}
+                />
+              );
+            })}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- make `isFavorite` prop optional on `TagButton`
- show filled star when a suggestion is already a favorite
- compute suggestion favorite state in `TasksTagInput`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6870db128608832580914d1b1ac77506