### PR TITLE
Implement smaller variant buttons

### DIFF
--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -3,7 +3,7 @@ import { Star, X } from 'lucide-react';
 interface TagButtonProps {
   label: string;
   isFavorite?: boolean;
-  variant: 'selected' | 'suggestion' | 'favorite';
+  variant: 'selected' | 'suggested' | 'favorite';
   type?: string;
   onToggleFavorite?: (label: string, type?: string) => void;
   onRemove?: () => void;
@@ -21,20 +21,22 @@ export default function TagButton({
   onEdit,
   onClick,
 }: TagButtonProps) {
-  const baseClasses =
-    'rounded-full text-sm border flex items-center gap-1 px-3 py-1';
+  const baseClasses = 'rounded-full border flex items-center gap-1';
+
+  const sizeClasses =
+    variant === 'selected' ? 'text-sm px-3 py-1' : 'text-sm px-2 py-1';
 
   let variantClasses = '';
   if (variant === 'selected') {
     variantClasses = 'bg-[#F29400] text-white border-[#F29400]';
-  } else if (variant === 'suggestion') {
+  } else if (variant === 'suggested') {
     variantClasses = 'bg-white text-gray-700 border-gray-300';
   } else {
     // favorite
     variantClasses = 'bg-white text-gray-700 border-[#F29400]';
   }
 
-  const starStroke = variant === 'suggestion' ? '#F29400' : 'white';
+  const starStroke = variant === 'suggested' ? '#F29400' : 'white';
   const starFill = isFavorite ? '#FDE047' : 'none';
 
   const handleToggleFavorite = (e: React.MouseEvent) => {
@@ -55,7 +57,11 @@ export default function TagButton({
 
 
   return (
-    <button type="button" onClick={onClick} className={`${baseClasses} ${variantClasses}`}>
+    <button
+      type="button"
+      onClick={onClick}
+      className={`${baseClasses} ${sizeClasses} ${variantClasses}`}
+    >
       <span onClick={variant === 'selected' ? handleLabelClick : undefined} className={onEdit ? 'cursor-text' : ''}>{label}</span>
       {variant !== 'favorite' && onToggleFavorite && (
         <span

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -133,7 +133,7 @@ export default function TasksTagInput({
                 <TagButton
                   key={s}
                   label={s}
-                  variant="suggestion"
+                  variant="suggested"
                   isFavorite={isFavorite}
                   onClick={() => addTask(s)}
                   type="task"


### PR DESCRIPTION
## Summary
- update `TagButton` with size variants and rename `suggestion` to `suggested`
- use `variant="suggested"` for task suggestions

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870de31ca2883258437bffaf7175753