### PR TITLE
UI-Fine-Tuning für Favoriten-Buttons und Eingabefelder

### DIFF
--- a/src/components/AutocompleteInput.tsx
+++ b/src/components/AutocompleteInput.tsx
@@ -11,6 +11,7 @@ interface AutocompleteInputProps {
   disabled?: boolean;
   className?: string;
   buttonColor?: string;
+  inputBorderColor?: string;
   showFavoritesButton?: boolean;
   showAddButton?: boolean;
   id?: string;
@@ -27,6 +28,7 @@ export default function AutocompleteInput({
   disabled = false,
   className = '',
   buttonColor = 'orange',
+  inputBorderColor = '#F29400',
   showFavoritesButton = false,
   showAddButton = true,
   id,
@@ -218,9 +220,9 @@ export default function AutocompleteInput({
             placeholder={placeholder}
             disabled={disabled}
             className="w-full px-3 py-2 border rounded-md text-sm focus:outline-none focus:ring-2"
-            style={{ 
-              borderColor: '#F29400',
-              '--tw-ring-color': '#F29400'
+            style={{
+              borderColor: inputBorderColor,
+              '--tw-ring-color': inputBorderColor
             } as React.CSSProperties}
             aria-expanded={isOpen}
             aria-haspopup="listbox"
@@ -232,7 +234,7 @@ export default function AutocompleteInput({
           {isOpen && filteredSuggestions.length > 0 && (
             <div 
               className="absolute top-full left-0 right-0 mt-1 bg-white border rounded-md shadow-lg max-h-48 overflow-y-auto z-50 autocomplete-dropdown" 
-              style={{ borderColor: '#F29400' }}
+              style={{ borderColor: inputBorderColor }}
               role="listbox"
               aria-label="Vorschläge"
             >

--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -33,7 +33,7 @@ export default function TagButton({
     variantClasses = 'bg-white text-gray-700 border-gray-300';
   } else {
     // favorite
-    variantClasses = 'bg-white text-gray-700 border-[#F29400]';
+    variantClasses = 'bg-white text-gray-700 border-[#FDE047]';
   }
 
   const starStroke = variant === 'suggested' ? '#F29400' : 'white';

--- a/src/components/TagSelectorWithFavorites.tsx
+++ b/src/components/TagSelectorWithFavorites.tsx
@@ -78,6 +78,7 @@ export default function TagSelectorWithFavorites({
         suggestions={options}
         placeholder="Hinzufügen..."
         buttonColor="orange"
+        inputBorderColor="#D1D5DB"
         showFavoritesButton={allowCustom}
         showAddButton={allowCustom}
         label={label}

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -82,6 +82,7 @@ export default function TasksTagInput({
         suggestions={filteredSuggestions}
         placeholder="Hinzufügen..."
         buttonColor="orange"
+        inputBorderColor="#D1D5DB"
         showFavoritesButton
       />
 


### PR DESCRIPTION
## Summary
- adjust favorite TagButton border color to yellow
- allow AutocompleteInput border color override
- show position and task inputs with neutral gray border

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870e2950cfc8325a35d741742058293