### PR TITLE
fix-tagbutton-favorite-icon

### DIFF
--- a/src/components/IconStar.tsx
+++ b/src/components/IconStar.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+interface IconStarProps {
+  filled?: boolean;
+  size?: number;
+  strokeColor?: string;
+}
+
+export default function IconStar({
+  filled = false,
+  size = 16,
+  strokeColor = '#F29400',
+}: IconStarProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill={filled ? '#FDE047' : 'none'}
+      stroke={filled ? 'none' : strokeColor}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <polygon points="12 2 15 8.5 22 9.3 17 14 18.2 21 12 17.8 5.8 21 7 14 2 9.3 9 8.5 12 2" />
+    </svg>
+  );
+}

--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -1,4 +1,5 @@
-import { Star, X } from 'lucide-react';
+import { X } from 'lucide-react';
+import IconStar from './IconStar';
 
 interface TagButtonProps {
   label: string;
@@ -36,8 +37,6 @@ export default function TagButton({
     variantClasses = 'bg-white text-gray-700 border-[#F29400]';
   }
 
-  const starStroke = '#F29400';
-  const starFill = isFavorite ? '#FDE047' : 'none';
 
   const handleToggleFavorite = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -66,12 +65,12 @@ export default function TagButton({
       {variant !== 'favorite' && onToggleFavorite && (
         <span
           onClick={handleToggleFavorite}
-          className="ml-1 cursor-pointer"
+          className="ml-auto pr-[6px] cursor-pointer flex"
           role="button"
           aria-label="Favorit"
           title="Favorit"
         >
-          <Star className="w-3 h-3" stroke={starStroke} fill={starFill} />
+          <IconStar filled={isFavorite} size={16} strokeColor="#F29400" />
         </span>
       )}
       {onRemove && (


### PR DESCRIPTION
## Summary
- ensure consistent star icon for TagButton
- add reusable `IconStar` component

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6870ed92dfa483258686b1375fb33c51