### PR TITLE
fix-unfilled-star-visibility

### DIFF
--- a/src/components/IconStar.tsx
+++ b/src/components/IconStar.tsx
@@ -3,13 +3,15 @@ import React from 'react';
 interface IconStarProps {
   filled?: boolean;
   size?: number;
-  strokeColor?: string;
+  stroke?: string;
+  strokeWidth?: number;
 }
 
 export default function IconStar({
   filled = false,
   size = 16,
-  strokeColor = '#F29400',
+  stroke = '#F29400',
+  strokeWidth = 2,
 }: IconStarProps) {
   return (
     <svg
@@ -17,8 +19,8 @@ export default function IconStar({
       height={size}
       viewBox="0 0 24 24"
       fill={filled ? '#FDE047' : 'none'}
-      stroke={filled ? 'none' : strokeColor}
-      strokeWidth="2"
+      stroke={filled ? 'none' : stroke}
+      strokeWidth={filled ? undefined : strokeWidth}
       strokeLinecap="round"
       strokeLinejoin="round"
     >

--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -75,7 +75,12 @@ export default function TagButton({
           aria-label="Favorit"
           title="Favorit"
         >
-          <IconStar filled={isFavorite} size={14} strokeColor="#F29400" />
+          <IconStar
+            filled={isFavorite}
+            size={14}
+            stroke="white"
+            strokeWidth={1.5}
+          />
         </span>
         {onRemove && (
           <button


### PR DESCRIPTION
## Summary
- tweak IconStar to allow passing stroke/strokeWidth
- show white outlined star for non-favorites in TagButton

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68710cd2f3608325996a2cfa6f228fbf