### PR TITLE
Contextual star visuals

### DIFF
--- a/src/components/IconStar.tsx
+++ b/src/components/IconStar.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 
 interface IconStarProps {
-  filled?: boolean;
   size?: number;
+  fill?: string;
   stroke?: string;
   strokeWidth?: number;
 }
 
 export default function IconStar({
-  filled = false,
   size = 16,
+  fill = 'none',
   stroke = '#F29400',
   strokeWidth = 2,
 }: IconStarProps) {
@@ -18,9 +18,9 @@ export default function IconStar({
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill={filled ? '#FDE047' : 'none'}
-      stroke={filled ? 'none' : stroke}
-      strokeWidth={filled ? undefined : strokeWidth}
+      fill={fill}
+      stroke={stroke}
+      strokeWidth={strokeWidth}
       strokeLinecap="round"
       strokeLinejoin="round"
     >

--- a/src/components/PositionTag.tsx
+++ b/src/components/PositionTag.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useLebenslaufContext } from '../context/LebenslaufContext';
 import TagButton from './TagButton';
+import TagContext from '../types/TagContext';
 
 interface PositionTagProps {
   label: string;
@@ -15,7 +16,7 @@ export default function PositionTag({ label, onRemove, onEdit }: PositionTagProp
   return (
     <TagButton
       label={label}
-      variant="selected"
+      variant={TagContext.Selected}
       isFavorite={isFavorite}
       type="position"
       onToggleFavorite={toggleFavoritePosition}

--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -1,10 +1,11 @@
 import { X } from 'lucide-react';
 import IconStar from './IconStar';
+import TagContext from '../types/TagContext';
 
 interface TagButtonProps {
   label: string;
   isFavorite?: boolean;
-  variant: 'selected' | 'suggested' | 'favorite';
+  variant: TagContext;
   type?: string;
   onToggleFavorite?: (label: string, type?: string) => void;
   onRemove?: () => void;
@@ -25,16 +26,34 @@ export default function TagButton({
   const baseClasses = 'rounded-full border flex items-center gap-1';
 
   const sizeClasses =
-    variant === 'selected' ? 'text-sm px-3 py-1' : 'text-sm px-2 py-1';
+    variant === TagContext.Selected ? 'text-sm px-3 py-1' : 'text-sm px-2 py-1';
 
   let variantClasses = '';
-  if (variant === 'selected') {
+  if (variant === TagContext.Selected) {
     variantClasses = 'bg-[#F29400] text-white border-[#F29400]';
-  } else if (variant === 'suggested') {
+  } else if (variant === TagContext.Suggestion) {
     variantClasses = 'bg-white text-gray-700 border-gray-300';
   } else {
-    // favorite
+    // favorites list
     variantClasses = 'bg-white text-gray-700 border-[#F29400]';
+  }
+
+  // Visual matrix for star appearance
+  /*
+    | Kontext      | Favorit? | stroke   | fill      |
+    |--------------|----------|----------|-----------|
+    | suggestion   | nein     | #888     | none      |
+    | suggestion   | ja       | #FDE047 | #FDE047  |
+    | selected     | nein     | white    | none      |
+    | selected     | ja       | #FDE047 | #FDE047  |
+    | favorites    | immer    | #FDE047 | #FDE047  |
+  */
+
+  let starStroke = variant === TagContext.Selected ? 'white' : '#888';
+  let starFill = 'none';
+  if (isFavorite) {
+    starStroke = '#FDE047';
+    starFill = '#FDE047';
   }
 
 
@@ -62,7 +81,7 @@ export default function TagButton({
       className={`${baseClasses} ${sizeClasses} ${variantClasses}`}
     >
       <span
-        onClick={variant === 'selected' ? handleLabelClick : undefined}
+        onClick={variant === TagContext.Selected ? handleLabelClick : undefined}
         className={onEdit ? 'cursor-text' : ''}
       >
         {label}
@@ -75,12 +94,7 @@ export default function TagButton({
           aria-label="Favorit"
           title="Favorit"
         >
-          <IconStar
-            filled={isFavorite}
-            size={14}
-            stroke="white"
-            strokeWidth={1.5}
-          />
+          <IconStar size={14} stroke={starStroke} fill={starFill} strokeWidth={1.5} />
         </span>
         {onRemove && (
           <button

--- a/src/components/TagSelectorWithFavorites.tsx
+++ b/src/components/TagSelectorWithFavorites.tsx
@@ -3,6 +3,7 @@ import { X } from 'lucide-react';
 import AutocompleteInput from './AutocompleteInput';
 import PositionTag from './PositionTag';
 import TagButton from './TagButton';
+import TagContext from '../types/TagContext';
 import { useLebenslaufContext } from '../context/LebenslaufContext';
 
 interface TagSelectorWithFavoritesProps {
@@ -140,7 +141,7 @@ export default function TagSelectorWithFavorites({
                 <TagButton
                   key={item}
                   label={item}
-                  variant="favorite"
+                  variant={TagContext.Favorites}
                   isFavorite
                   type="position"
                   onClick={() => addTag(item)}

--- a/src/components/TaskTag.tsx
+++ b/src/components/TaskTag.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useLebenslaufContext } from '../context/LebenslaufContext';
 import TagButton from './TagButton';
+import TagContext from '../types/TagContext';
 
 interface TaskTagProps {
   label: string;
@@ -15,7 +16,7 @@ export default function TaskTag({ label, onRemove, onEdit }: TaskTagProps) {
   return (
     <TagButton
       label={label}
-      variant="selected"
+      variant={TagContext.Selected}
       isFavorite={isFavorite}
       type="task"
       onToggleFavorite={toggleFavoriteTask}

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from "react";
 import { Lightbulb, X } from "lucide-react";
 import TaskTag from "./TaskTag";
 import TagButton from "./TagButton";
+import TagContext from "../types/TagContext";
 import AutocompleteInput from "./AutocompleteInput";
 import { getTasksForPositions } from "../constants/positionsToTasks";
 import { useLebenslaufContext } from "../context/LebenslaufContext";
@@ -129,7 +130,7 @@ export default function TasksTagInput({
                 <TagButton
                   key={s}
                   label={s}
-                  variant="suggested"
+                  variant={TagContext.Suggestion}
                   isFavorite={isFavorite}
                   onClick={() => addTask(s)}
                   type="task"
@@ -168,7 +169,7 @@ export default function TasksTagInput({
                 <TagButton
                   key={item}
                   label={item}
-                  variant="favorite"
+                  variant={TagContext.Favorites}
                   isFavorite
                   type="task"
                   onClick={() => addTask(item)}

--- a/src/types/TagContext.ts
+++ b/src/types/TagContext.ts
@@ -1,0 +1,7 @@
+export enum TagContext {
+  Selected = 'selected',
+  Suggestion = 'suggestion',
+  Favorites = 'favorites',
+}
+
+export default TagContext;


### PR DESCRIPTION
## Summary
- add `TagContext` enum for consistent tag variant naming
- enhance `<IconStar>` with fill/stroke props
- update `<TagButton>` to use context-based star colors
- adjust related components to use `TagContext`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_687110c047d08325aaf16435a7702423