### PR TITLE
Remove duplicate labels in ExperienceForm

### DIFF
--- a/src/components/ExperienceForm.tsx
+++ b/src/components/ExperienceForm.tsx
@@ -68,7 +68,6 @@ export default function ExperienceForm({
       <div className="bg-white border border-gray-200 rounded shadow-sm p-4">
         <h3 className="text-sm font-medium text-gray-700 mb-2">Positionen</h3>
         <TagSelectorWithFavorites
-          label="Positionen"
           value={selectedPositions}
           onChange={(val) => {
             onPositionsChange(val);

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -66,9 +66,6 @@ export default function TasksTagInput({
 
   return (
     <div className="space-y-4">
-      <h3 className="text-sm font-medium text-gray-700">
-        Aufgaben/Tätigkeiten
-      </h3>
 
       <AutocompleteInput
         value={inputValue}


### PR DESCRIPTION
## Summary
- clean up ExperienceForm UI labels
- remove inner heading from tasks input

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687123d766ac8325b627e709d703a6af