### PR TITLE
Improve MonthYearInput behaviour

### DIFF
--- a/src/components/MonthYearInput.tsx
+++ b/src/components/MonthYearInput.tsx
@@ -1,9 +1,40 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 
-export default function MonthYearInput() {
-  const [value, setValue] = useState('');
+interface MonthYearInputProps {
+  value?: string;
+  onChange?: (value: string) => void;
+}
+export default function MonthYearInput({ value = '', onChange }: MonthYearInputProps) {
+  const [month, setMonth] = useState('');
+  const [year, setYear] = useState('');
   const textRef = useRef<HTMLInputElement>(null);
   const pickerRef = useRef<HTMLInputElement>(null);
+
+  const displayValue = () => {
+    if (month) {
+      if (year) return `${month}/${year}`;
+      if (month.length === 2) return `${month}/`;
+      return month;
+    }
+    return year;
+  };
+
+  const parseValue = (val: string) => {
+    if (/^\d{2}\/\d{4}$/.test(val)) {
+      return { month: val.slice(0, 2), year: val.slice(3) };
+    }
+    if (/^\d{4}$/.test(val)) {
+      return { month: '', year: val };
+    }
+    return { month: '', year: '' };
+  };
+
+  useEffect(() => {
+    const parsed = parseValue(value);
+    if (parsed.month !== month) setMonth(parsed.month);
+    if (parsed.year !== year) setYear(parsed.year);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
 
   const formatInput = (
     raw: string,
@@ -53,18 +84,28 @@ export default function MonthYearInput() {
     return { value: formatted, caret };
   };
 
-  const handleTextChange = (
-    e: React.ChangeEvent<HTMLInputElement>
-  ) => {
+  const handleTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const input = e.target;
     const pos = input.selectionStart ?? input.value.length;
+    const current = displayValue();
     const { value: newVal, caret } = formatInput(
       input.value,
-      value,
+      current,
       pos,
       (e.nativeEvent as InputEvent).inputType || ''
     );
-    setValue(newVal);
+    const digits = newVal.replace(/\D/g, '');
+    let newMonth = '';
+    let newYear = '';
+    if (digits.length <= 2) {
+      newMonth = digits;
+    } else {
+      newMonth = digits.slice(0, 2);
+      newYear = digits.slice(2, 6);
+    }
+    setMonth(newMonth);
+    setYear(newYear);
+    onChange?.(newVal);
     setTimeout(() => {
       textRef.current?.setSelectionRange(caret, caret);
     }, 0);
@@ -73,10 +114,12 @@ export default function MonthYearInput() {
   const handlePickerChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
-    const [year, month] = e.target.value.split('-');
-    if (year && month) {
-      const formatted = `${month}/${year}`;
-      setValue(formatted);
+    const [yearStr, monthStr] = e.target.value.split('-');
+    if (yearStr && monthStr) {
+      setMonth(monthStr);
+      setYear(yearStr);
+      const formatted = `${monthStr}/${yearStr}`;
+      onChange?.(formatted);
       textRef.current?.focus();
       setTimeout(() => {
         const p = formatted.length;
@@ -94,10 +137,43 @@ export default function MonthYearInput() {
     if (!input) return;
     const pos = input.selectionStart ?? 0;
     if (pos <= 2) {
-      setTimeout(() => input.setSelectionRange(0, 2), 0);
+      setTimeout(() => input.setSelectionRange(0, Math.min(2, input.value.length)), 0);
     } else {
-      setTimeout(() => input.setSelectionRange(3, 7), 0);
+      const start = month ? 3 : 0;
+      setTimeout(() => input.setSelectionRange(start, input.value.length), 0);
     }
+  };
+
+  const handleFocus = () => {
+    const input = textRef.current;
+    if (!input) return;
+    setTimeout(() => input.setSelectionRange(0, Math.min(2, input.value.length)), 0);
+  };
+
+  const invalid =
+    (month.length === 2 && (Number(month) < 1 || Number(month) > 12)) ||
+    (year.length === 4 && (Number(year) < 1900 || Number(year) > 2099));
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+    const inc = e.key === 'ArrowUp' ? 1 : -1;
+    let numYear = Number(year || '1900');
+    numYear += inc;
+    if (numYear < 1900) numYear = 1900;
+    if (numYear > 2099) numYear = 2099;
+    const newYear = String(numYear);
+    setYear(newYear);
+    const newVal = month ? `${month}/${newYear}` : newYear;
+    onChange?.(newVal);
+    setTimeout(() => {
+      const input = textRef.current;
+      if (input) {
+        const start = month ? 3 : 0;
+        const end = newVal.length;
+        input.setSelectionRange(start, end);
+      }
+    }, 0);
+    e.preventDefault();
   };
 
   return (
@@ -105,14 +181,16 @@ export default function MonthYearInput() {
       <input
         type="text"
         placeholder="MM/YYYY"
-        value={value}
+        value={displayValue()}
         onChange={handleTextChange}
         onClick={handleClick}
+        onFocus={handleFocus}
+        onKeyDown={handleKeyDown}
         ref={textRef}
         inputMode="numeric"
         pattern="\d{2}/\d{4}"
         maxLength={7}
-        className="border px-2 py-1 rounded w-28"
+        className={`border px-2 py-1 rounded w-28 ${invalid ? 'border-red-500' : ''}`}
       />
       <button
         type="button"


### PR DESCRIPTION
## Summary
- split month and year into dedicated states
- keep user input synchronized with year-month picker
- clamp arrow up/down year increments
- highlight invalid month or year with red border

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6871560a52848325a38c4853159b0290