### PR TITLE
Improve Tag star & company editing

### DIFF
--- a/src/components/CompaniesTagInput.tsx
+++ b/src/components/CompaniesTagInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import TagButton from './TagButton';
 import TagContext from '../types/TagContext';
 import { useLebenslaufContext } from '../context/LebenslaufContext';
@@ -10,6 +10,7 @@ interface CompaniesTagInputProps {
 
 export default function CompaniesTagInput({ value, onChange }: CompaniesTagInputProps) {
   const [inputValue, setInputValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
   const { favoriteCompanies: favorites, toggleFavoriteCompany } = useLebenslaufContext();
 
   const addCompany = (val?: string) => {
@@ -17,6 +18,12 @@ export default function CompaniesTagInput({ value, onChange }: CompaniesTagInput
     if (!c || value.includes(c)) return;
     onChange([...value, c]);
     setInputValue('');
+  };
+
+  const handleEditCompany = (label: string) => {
+    removeCompany(label);
+    setInputValue(label);
+    setTimeout(() => inputRef.current?.focus(), 0);
   };
 
   const removeCompany = (c: string) => {
@@ -33,6 +40,7 @@ export default function CompaniesTagInput({ value, onChange }: CompaniesTagInput
   return (
     <div className="space-y-2">
       <input
+        ref={inputRef}
         type="text"
         placeholder="Firma hinzufügen..."
         className="w-full px-3 py-2 border rounded"
@@ -50,6 +58,7 @@ export default function CompaniesTagInput({ value, onChange }: CompaniesTagInput
               isFavorite={favorites.includes(c)}
               onToggleFavorite={toggleFavoriteCompany}
               onRemove={() => removeCompany(c)}
+              onEdit={() => handleEditCompany(c)}
               type="company"
             />
           ))}

--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -38,22 +38,16 @@ export default function TagButton({
     variantClasses = 'bg-white text-gray-700 border-[#F29400]';
   }
 
-  // Visual matrix for star appearance
-  /*
-    | Kontext      | Favorit? | stroke   | fill      |
-    |--------------|----------|----------|-----------|
-    | suggestion   | nein     | #888     | none      |
-    | suggestion   | ja       | #FDE047 | #FDE047  |
-    | selected     | nein     | white    | none      |
-    | selected     | ja       | #FDE047 | #FDE047  |
-    | favorites    | immer    | #FDE047 | #FDE047  |
-  */
+  const starSize = isFavorite ? 16 : 14;
 
-  let starStroke = variant === TagContext.Selected ? '#ffffff' : '#4B5563';
+  let starStroke = '#4B5563';
   let starFill = 'none';
-  if (isFavorite || variant === TagContext.Favorites) {
+
+  if (isFavorite) {
     starStroke = '#F29400';
     starFill = '#FDE047';
+  } else if (variant === TagContext.Selected) {
+    starStroke = '#ffffff';
   }
 
 
@@ -94,7 +88,12 @@ export default function TagButton({
           aria-label="Favorit"
           title="Favorit"
         >
-          <IconStar size={14} stroke={starStroke} fill={starFill} strokeWidth={1.5} />
+          <IconStar
+            size={starSize}
+            stroke={starStroke}
+            fill={starFill}
+            strokeWidth={2}
+          />
         </span>
         {onRemove && (
           <button


### PR DESCRIPTION
## Summary
- tweak star icon for selected favorites
- enable editing company tags inline

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6871610c4f2483259421ff1ba4a23fc7