### PR TITLE
Implement inline edit for companies and update date input

### DIFF
--- a/src/components/CompaniesTagInput.tsx
+++ b/src/components/CompaniesTagInput.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from 'react';
+import CompanyTag from './CompanyTag';
 import TagButton from './TagButton';
 import TagContext from '../types/TagContext';
 import { useLebenslaufContext } from '../context/LebenslaufContext';
@@ -11,7 +12,8 @@ interface CompaniesTagInputProps {
 export default function CompaniesTagInput({ value, onChange }: CompaniesTagInputProps) {
   const [inputValue, setInputValue] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
-  const { favoriteCompanies: favorites, toggleFavoriteCompany } = useLebenslaufContext();
+  const { favoriteCompanies: favorites, toggleFavoriteCompany } =
+    useLebenslaufContext();
 
   const addCompany = (val?: string) => {
     const c = (val ?? inputValue).trim();
@@ -20,14 +22,12 @@ export default function CompaniesTagInput({ value, onChange }: CompaniesTagInput
     setInputValue('');
   };
 
-  const handleEditCompany = (label: string) => {
-    removeCompany(label);
-    setInputValue(label);
-    setTimeout(() => inputRef.current?.focus(), 0);
-  };
-
   const removeCompany = (c: string) => {
     onChange(value.filter((v) => v !== c));
+  };
+
+  const updateCompany = (oldVal: string, newVal: string) => {
+    onChange(value.map((v) => (v === oldVal ? newVal : v)));
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -51,15 +51,11 @@ export default function CompaniesTagInput({ value, onChange }: CompaniesTagInput
       {value.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {value.map((c) => (
-            <TagButton
+            <CompanyTag
               key={c}
               label={c}
-              variant={TagContext.Selected}
-              isFavorite={favorites.includes(c)}
-              onToggleFavorite={toggleFavoriteCompany}
               onRemove={() => removeCompany(c)}
-              onEdit={() => handleEditCompany(c)}
-              type="company"
+              onEdit={(val) => updateCompany(c, val)}
             />
           ))}
         </div>

--- a/src/components/CompanyTag.tsx
+++ b/src/components/CompanyTag.tsx
@@ -1,0 +1,73 @@
+import { useState, useRef, useEffect } from 'react';
+import { X } from 'lucide-react';
+import { useLebenslaufContext } from '../context/LebenslaufContext';
+import TagButton from './TagButton';
+import TagContext from '../types/TagContext';
+
+interface CompanyTagProps {
+  label: string;
+  onRemove: () => void;
+  onEdit: (value: string) => void;
+}
+
+export default function CompanyTag({ label, onRemove, onEdit }: CompanyTagProps) {
+  const { favoriteCompanies, toggleFavoriteCompany } = useLebenslaufContext();
+  const isFavorite = favoriteCompanies.includes(label);
+
+  const [editing, setEditing] = useState(false);
+  const [editValue, setEditValue] = useState(label);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) {
+      setEditValue(label);
+      inputRef.current?.focus();
+    }
+  }, [editing, label]);
+
+  const confirmEdit = () => {
+    setEditing(false);
+    const trimmed = editValue.trim();
+    if (trimmed && trimmed !== label) {
+      onEdit(trimmed);
+    }
+  };
+
+  if (editing) {
+    return (
+      <div className="tag">
+        <input
+          ref={inputRef}
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onBlur={confirmEdit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') confirmEdit();
+          }}
+          className="text-black px-1 py-0.5 rounded"
+          autoFocus
+        />
+        <button
+          onClick={onRemove}
+          className="tag-icon-button"
+          aria-label="Entfernen"
+        >
+          <X className="tag-icon" />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <TagButton
+      label={label}
+      variant={TagContext.Selected}
+      isFavorite={isFavorite}
+      type="company"
+      onToggleFavorite={toggleFavoriteCompany}
+      onRemove={onRemove}
+      onEdit={() => setEditing(true)}
+    />
+  );
+}
+

--- a/src/components/MonthYearInput.tsx
+++ b/src/components/MonthYearInput.tsx
@@ -36,79 +36,30 @@ export default function MonthYearInput({ value = '', onChange }: MonthYearInputP
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
-  const formatInput = (
-    raw: string,
-    prev: string,
-    pos: number,
-    inputType: string
-  ) => {
-    const isDelete = inputType.startsWith('delete');
-    const hasSlash = raw.includes('/');
-    const digits = raw.replace(/\D/g, '').slice(0, 6);
-    const prevDigits = prev.replace(/\D/g, '');
-    let caret = pos;
-    let formatted = '';
-
-    if (isDelete) {
-      if (hasSlash) {
-        const [m, y] = raw.split('/');
-        const month = m.replace(/\D/g, '').slice(0, 2);
-        const year = y.replace(/\D/g, '').slice(0, 4);
-        formatted = month + (raw.includes('/') ? '/' : '') + year;
-      } else {
-        if (digits.length > 2) {
-          formatted = digits.slice(0, 2) + '/' + digits.slice(2);
-        } else {
-          formatted = digits;
-        }
-      }
-    } else {
-      if (digits.length <= 2) {
-        formatted = digits;
-        if (
-          digits.length === 2 &&
-          !hasSlash &&
-          prevDigits.length < 2
-        ) {
-          formatted += '/';
-          if (caret >= 2) caret += 1;
-        } else if (hasSlash) {
-          formatted += '/';
-        }
-      } else {
-        formatted = digits.slice(0, 2) + '/' + digits.slice(2);
-        if (!prev.includes('/') && caret > 2) caret += 1;
-      }
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    let raw = e.target.value.replace(/[^0-9]/g, '');
+    if (raw.length === 0) {
+      setMonth('');
+      setYear('');
+      onChange?.('');
+      return;
     }
 
-    return { value: formatted, caret };
-  };
-
-  const handleTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const input = e.target;
-    const pos = input.selectionStart ?? input.value.length;
-    const current = displayValue();
-    const { value: newVal, caret } = formatInput(
-      input.value,
-      current,
-      pos,
-      (e.nativeEvent as InputEvent).inputType || ''
-    );
-    const digits = newVal.replace(/\D/g, '');
-    let newMonth = '';
-    let newYear = '';
-    if (digits.length <= 2) {
-      newMonth = digits;
-    } else {
-      newMonth = digits.slice(0, 2);
-      newYear = digits.slice(2, 6);
+    if (raw.length <= 2 && Number(raw) >= 1 && Number(raw) <= 12) {
+      const m = raw.padStart(2, '0');
+      setMonth(m);
+      setYear('');
+      onChange?.(m + '/');
+      return;
     }
-    setMonth(newMonth);
-    setYear(newYear);
-    onChange?.(newVal);
-    setTimeout(() => {
-      textRef.current?.setSelectionRange(caret, caret);
-    }, 0);
+
+    if (raw.length >= 4) {
+      const m = raw.slice(0, 2);
+      const y = raw.slice(2, 6);
+      setMonth(m);
+      setYear(y);
+      onChange?.(`${m}/${y}`);
+    }
   };
 
   const handlePickerChange = (
@@ -182,7 +133,7 @@ export default function MonthYearInput({ value = '', onChange }: MonthYearInputP
         type="text"
         placeholder="MM/YYYY"
         value={displayValue()}
-        onChange={handleTextChange}
+        onChange={handleChange}
         onClick={handleClick}
         onFocus={handleFocus}
         onKeyDown={handleKeyDown}

--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -38,7 +38,7 @@ export default function TagButton({
     variantClasses = 'bg-white text-gray-700 border-[#F29400]';
   }
 
-  const starSize = isFavorite ? 16 : 14;
+  const starSize = isFavorite ? 18 : 14;
 
   let starStroke = '#4B5563';
   let starFill = 'none';
@@ -80,7 +80,7 @@ export default function TagButton({
       >
         {label}
       </span>
-      <div className="ml-auto flex items-center gap-[4px] justify-end">
+      <div className="ml-auto flex items-center gap-[6px] justify-end">
         <span
           onClick={onToggleFavorite ? handleToggleFavorite : undefined}
           className={`${onToggleFavorite ? 'cursor-pointer flex' : 'flex'} w-[14px] h-[14px]`}


### PR DESCRIPTION
## Summary
- enable inline editing of companies with new CompanyTag component
- use CompanyTag inside CompaniesTagInput and add updateCompany helper
- adjust star size for favorites in TagButton
- simplify MonthYearInput change handling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687165571bfc83259fcf9cf54b1992b3