### PR TITLE
Adjust star icon size and month deletion logic

### DIFF
--- a/src/components/MonthYearInput.tsx
+++ b/src/components/MonthYearInput.tsx
@@ -176,7 +176,23 @@ export default function MonthYearInput({ value = '', onChange }: MonthYearInputP
         onChange={handleChange}
         onMouseUp={handleMouseUp}
         onFocus={handleFocus}
-        onKeyDown={handleKeyDown}
+        onKeyDown={(e) => {
+          if (e.key === 'Backspace') {
+            const caret = textRef.current?.selectionStart ?? 0;
+            const sel = (textRef.current?.selectionEnd ?? caret) - caret;
+
+            if (caret <= 2 || sel > 0) {
+              e.preventDefault();
+              setMonth('');
+              const newVal = year ? '/' + year : '';
+              setIsInvalid(!(isMonth('') && isYear(year)));
+              onChange?.(newVal);
+              setTimeout(() => textRef.current?.setSelectionRange(0, 0));
+              return;
+            }
+          }
+          handleKeyDown(e);
+        }}
         ref={textRef}
         inputMode="numeric"
         pattern="\d{2}/\d{4}"

--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -48,7 +48,7 @@ export default function TagButton({
     starStroke = '#FFFFFF';
   }
 
-  const starSize = isFavorite ? 20 : 14;
+  const starSize = isFavorite ? 16 : 14;
 
 
   const handleToggleFavorite = (e: React.MouseEvent) => {


### PR DESCRIPTION
## Summary
- fine-tune star icon sizing in `TagButton`
- update `MonthYearInput` so Backspace clears month portion

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_687179943b94832593ae14712e28aacc