### PR TITLE
Fix month backspace logic and favorite tag style

### DIFF
--- a/src/components/MonthYearInput.tsx
+++ b/src/components/MonthYearInput.tsx
@@ -179,14 +179,10 @@ export default function MonthYearInput({ value = '', onChange }: MonthYearInputP
         onKeyDown={(e) => {
           if (e.key === 'Backspace') {
             const caret = textRef.current?.selectionStart ?? 0;
-            const sel = (textRef.current?.selectionEnd ?? caret) - caret;
-
-            if (caret <= 2 || sel > 0) {
+            if (caret < 2 && month) {
               e.preventDefault();
               setMonth('');
-              const newVal = year ? '/' + year : '';
-              setIsInvalid(!(isMonth('') && isYear(year)));
-              onChange?.(newVal);
+              onChange?.(year ? year : '');
               setTimeout(() => textRef.current?.setSelectionRange(0, 0));
               return;
             }

--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -38,6 +38,10 @@ export default function TagButton({
     variantClasses = 'bg-white text-gray-700 border-[#F29400]';
   }
 
+  if (variant === TagContext.Favorites) {
+    variantClasses = 'bg-gray-100 border-gray-300 text-gray-700';
+  }
+
   let starStroke = '#4B5563';
   let starFill = 'none';
 


### PR DESCRIPTION
## Summary
- handle backspace in `MonthYearInput` so deleting the month portion removes the slash
- style favorite tags with grey background

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68717c796c988325be5ba39990099e2d