### PR TITLE
UI Verbesserungen und Debug-Ansicht

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { Routes, Route, useNavigate } from 'react-router-dom';
 import { Settings } from 'lucide-react';
 import SettingsPage from './components/SettingsPage';
+import StyleTest from './pages/StyleTest';
 import TabNavigation from './components/layout/TabNavigation';
 import InputColumns from './components/layout/InputColumns';
 import DocumentTypeBlock from './components/layout/DocumentTypeBlock';
@@ -561,6 +562,7 @@ function App() {
     <Routes>
       <Route path="/" element={<HomePage />} />
       <Route path="/settings" element={<SettingsPage />} />
+      <Route path="/style-test" element={<StyleTest />} />
     </Routes>
   );
 }

--- a/src/components/CompaniesTagInput.tsx
+++ b/src/components/CompaniesTagInput.tsx
@@ -85,7 +85,7 @@ export default function CompaniesTagInput({ value, onChange }: CompaniesTagInput
                 <TagButton
                   key={f}
                   label={f}
-                  variant={TagContext.Favorites}
+                  variant={TagContext.Favorite}
                   isFavorite
                   onClick={() => addCompany(f)}
                   onRemove={() => toggleFavoriteCompany(f)}

--- a/src/components/MonthYearInput.tsx
+++ b/src/components/MonthYearInput.tsx
@@ -1,214 +1,121 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 interface MonthYearInputProps {
   value?: string;
   onChange?: (value: string) => void;
 }
+
 export default function MonthYearInput({ value = '', onChange }: MonthYearInputProps) {
   const [month, setMonth] = useState('');
   const [year, setYear] = useState('');
-  const [isInvalid, setIsInvalid] = useState(false);
-  const textRef = useRef<HTMLInputElement>(null);
+  const [invalid, setInvalid] = useState(false);
+  const monthRef = useRef<HTMLInputElement>(null);
+  const yearRef = useRef<HTMLInputElement>(null);
   const pickerRef = useRef<HTMLInputElement>(null);
 
-  const selectPart = (pos: number) => {
-    const input = textRef.current;
-    if (!input) return;
-    if (pos <= 2) {
-      setTimeout(() => input.setSelectionRange(0, 2), 0);
-    } else {
-      setTimeout(() => input.setSelectionRange(3, 7), 0);
-    }
-  };
-
-  const displayValue = () => {
-    if (month) {
-      if (year) return `${month}/${year}`;
-      if (month.length === 2) return `${month}/`;
-      return month;
-    }
-    return year;
-  };
-
-  const parseValue = (val: string) => {
-    if (/^\d{2}\/\d{4}$/.test(val)) {
-      return { month: val.slice(0, 2), year: val.slice(3) };
-    }
-    if (/^\d{4}$/.test(val)) {
-      return { month: '', year: val };
-    }
-    return { month: '', year: '' };
-  };
-
-  const isMonth = (val: string) => /^(0[1-9]|1[0-2])$/.test(val);
-
-  const isYear = (val: string) =>
-    /^(19(5[5-9]|[6-9]\d)|20([0-4]\d|5[0-5]))$/.test(val);
+  const isMonth = (m: string) => /^(0[1-9]|1[0-2])$/.test(m);
+  const isYear = (y: string) => /^(19(5[5-9]|[6-9]\d)|20([0-4]\d|5[0-5]))$/.test(y);
 
   useEffect(() => {
-    const parsed = parseValue(value);
-    if (parsed.month !== month) setMonth(parsed.month);
-    if (parsed.year !== year) setYear(parsed.year);
-    setIsInvalid(!(isMonth(parsed.month) && isYear(parsed.year)));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value]);
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const raw = e.target.value.replace(/[^0-9]/g, '');
-
-    if (raw.length === 0) {
+    const match = value.match(/^(\d{2})\/(\d{4})$/);
+    if (match) {
+      setMonth(match[1]);
+      setYear(match[2]);
+      setInvalid(!(isMonth(match[1]) && isYear(match[2])));
+    } else if (/^\d{4}$/.test(value)) {
+      setMonth('');
+      setYear(value);
+      setInvalid(!isYear(value));
+    } else {
       setMonth('');
       setYear('');
-      setIsInvalid(false);
-      onChange?.('');
-      return;
+      setInvalid(false);
     }
+  }, [value]);
 
-    if (raw.length === 2 && isMonth(raw)) {
-      setMonth(raw);
-      setYear('');
-      setIsInvalid(!(isMonth(raw) && isYear('')));
-      onChange?.(`${raw}/`);
-      return;
-    }
-
-    const m = raw.slice(0, 2);
-    const y = raw.slice(2, 6);
-    setMonth(m);
-    setYear(y);
-    const valid = isMonth(m) && isYear(y);
-    setIsInvalid(!valid);
-
-    let formatted = m;
-    if (y) formatted += `/${y}`;
-    onChange?.(formatted);
-  };
-
-  const handlePickerChange = (
-    e: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    const [yearStr, monthStr] = e.target.value.split('-');
-    if (yearStr && monthStr) {
-      setMonth(monthStr);
-      setYear(yearStr);
-      setIsInvalid(!(isMonth(monthStr) && isYear(yearStr)));
-      const formatted = `${monthStr}/${yearStr}`;
-      onChange?.(formatted);
-      textRef.current?.focus();
-      setTimeout(() => {
-        const p = formatted.length;
-        textRef.current?.setSelectionRange(p, p);
-      }, 0);
-    }
-  };
-
-  const openPicker = () => {
-    pickerRef.current?.showPicker();
-  };
-
-  const handleMouseUp = () => {
-    const pos = textRef.current?.selectionStart ?? 0;
-    selectPart(pos);
-  };
-
-  const handleFocus = () => {
-    const pos = textRef.current?.selectionStart ?? 0;
-    selectPart(pos);
-  };
-
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    const input = e.currentTarget;
-
-    if (e.key === 'Backspace') {
-      const selStart = input.selectionStart ?? 0;
-      const selEnd = input.selectionEnd ?? 0;
-      if (selStart === selEnd && selStart === 3) {
-        e.preventDefault();
-        setMonth('');
-        setIsInvalid(!(isMonth('') && isYear(year)));
-        onChange?.(year);
-        setTimeout(() => {
-          const node = textRef.current;
-          if (node) node.setSelectionRange(0, year.length);
-        }, 0);
-        return;
+  const emit = (m: string, y: string) => {
+    if (!onChange) return;
+    if (m) {
+      if (y) {
+        onChange(`${m}/${y}`);
+      } else if (m.length === 2) {
+        onChange(`${m}/`);
+      } else {
+        onChange(m);
       }
+    } else {
+      onChange(y);
     }
+  };
 
-    if (e.key === '/') {
-      const raw = input.value.replace(/[^0-9]/g, '');
-      const m = parseInt(raw.slice(0, 2), 10);
-      if (raw.length !== 2 || m < 1 || m > 12) {
-        e.preventDefault();
-      }
-      return;
+  const handleMonthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    let val = e.target.value.replace(/\D/g, '').slice(0, 2);
+    setMonth(val);
+    if (val.length === 2 && isMonth(val)) {
+      yearRef.current?.focus();
     }
+    setInvalid(!(isMonth(val) && isYear(year)));
+    emit(val, year);
+  };
 
-    if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
-    const inc = e.key === 'ArrowUp' ? 1 : -1;
-    let numYear = Number(year || '1955');
-    numYear += inc;
-    if (numYear < 1955) numYear = 1955;
-    if (numYear > 2055) numYear = 2055;
-    const newYear = String(numYear);
-    setYear(newYear);
-    const newVal = month ? `${month}/${newYear}` : newYear;
-    setIsInvalid(!(isMonth(month) && isYear(newYear)));
-    onChange?.(newVal);
-    setTimeout(() => {
-      const node = textRef.current;
-      if (node) {
-        const start = month ? 3 : 0;
-        const end = newVal.length;
-        node.setSelectionRange(start, end);
-      }
-    }, 0);
-    e.preventDefault();
+  const handleYearChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    let val = e.target.value.replace(/\D/g, '').slice(0, 4);
+    if (val) {
+      let num = parseInt(val, 10);
+      if (num < 1955) num = 1955;
+      if (num > 2055) num = 2055;
+      val = String(num).slice(0, 4);
+    }
+    setYear(val);
+    setInvalid(!(isMonth(month) && isYear(val)));
+    emit(month, val);
+  };
+
+  const handlePickerChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const [y, m] = e.target.value.split('-');
+    if (y && m) {
+      setMonth(m);
+      setYear(y);
+      setInvalid(!(isMonth(m) && isYear(y)));
+      onChange?.(`${m}/${y}`);
+      yearRef.current?.focus();
+    }
   };
 
   return (
-    <div className="relative inline-flex items-center">
+    <div className="relative inline-flex items-center gap-1">
       <input
+        ref={monthRef}
         type="text"
-        placeholder="MM/YYYY"
-        value={displayValue()}
-        onChange={handleChange}
-        onMouseUp={handleMouseUp}
-        onFocus={handleFocus}
-        onKeyDown={(e) => {
-          if (e.key === 'Backspace') {
-            const caret = textRef.current?.selectionStart ?? 0;
-            if (caret < 2 && month) {
-              e.preventDefault();
-              setMonth('');
-              onChange?.(year ? year : '');
-              setTimeout(() => textRef.current?.setSelectionRange(0, 0));
-              return;
-            }
-          }
-          handleKeyDown(e);
-        }}
-        ref={textRef}
+        placeholder="MM"
+        value={month}
+        onChange={handleMonthChange}
         inputMode="numeric"
-        pattern="\d{2}/\d{4}"
-        maxLength={7}
-        className={`border px-2 py-1 rounded w-28 ${isInvalid ? 'border-red-500' : 'border-gray-300'}`}
+        className={`border rounded w-12 px-1 text-center ${invalid ? 'border-red-500' : 'border-gray-300'}`}
+      />
+      <span>/</span>
+      <input
+        ref={yearRef}
+        type="text"
+        placeholder="YYYY"
+        value={year}
+        onChange={handleYearChange}
+        inputMode="numeric"
+        className={`border rounded w-16 px-1 text-center ${invalid ? 'border-red-500' : 'border-gray-300'}`}
       />
       <button
         type="button"
-        onClick={openPicker}
+        onClick={() => pickerRef.current?.showPicker()}
         className="absolute right-1 text-gray-500"
       >
         &#x1F4C5;
       </button>
       <input
-        type="month"
         ref={pickerRef}
+        type="month"
         onChange={handlePickerChange}
         style={{ position: 'absolute', left: '-9999px' }}
       />
     </div>
   );
 }
-

--- a/src/components/MonthYearPicker.tsx
+++ b/src/components/MonthYearPicker.tsx
@@ -211,7 +211,7 @@ export default function MonthYearPicker({
           ref={popupRef}
           className="absolute left-0 mt-1 z-10 bg-white border rounded shadow p-2 w-max"
         >
-          <div className="grid grid-cols-3 gap-x-4">
+          <div className="grid grid-cols-3 gap-x-6">
             <div className="col-span-2 grid grid-cols-2 gap-2 text-sm">
               {months.map((m, i) => (
                 <button
@@ -233,7 +233,7 @@ export default function MonthYearPicker({
                 <button
                   key={y}
                   type="button"
-                  className="py-2 px-3 text-center w-full rounded-md text-sm bg-gray-50 hover:bg-gray-100"
+                  className="text-center py-2 w-full rounded-md text-sm bg-gray-50 hover:bg-gray-100"
                   onClick={() => selectYear(y)}
                 >
                   {y}

--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -5,7 +5,7 @@ import TagContext from '../types/TagContext';
 interface TagButtonProps {
   label: string;
   isFavorite?: boolean;
-  variant: TagContext;
+  variant: 'selected' | 'suggestion' | 'favorite';
   type?: string;
   onToggleFavorite?: (label: string, type?: string) => void;
   onRemove?: () => void;
@@ -33,13 +33,10 @@ export default function TagButton({
     variantClasses = 'bg-[#F29400] text-white border-[#F29400]';
   } else if (variant === TagContext.Suggestion) {
     variantClasses = 'bg-white text-gray-700 border-gray-300';
-  } else {
-    // favorites list
-    variantClasses = 'bg-white text-gray-700 border-[#F29400]';
-  }
-
-  if (variant === TagContext.Favorites) {
+  } else if (variant === TagContext.Favorite) {
     variantClasses = 'bg-gray-100 border-gray-300 text-gray-700';
+  } else {
+    variantClasses = 'bg-white text-gray-700 border-[#F29400]';
   }
 
   let starStroke = '#4B5563';
@@ -52,7 +49,7 @@ export default function TagButton({
     starStroke = '#FFFFFF';
   }
 
-  const starSize = isFavorite ? 16 : 14;
+  const starSize = 14;
 
 
   const handleToggleFavorite = (e: React.MouseEvent) => {
@@ -88,7 +85,7 @@ export default function TagButton({
         {isFavorite && (
           <span
             onClick={onToggleFavorite ? handleToggleFavorite : undefined}
-            className={onToggleFavorite ? 'cursor-pointer -mx-0.5' : '-mx-0.5'}
+            className={onToggleFavorite ? 'cursor-pointer' : ''}
             role="button"
             aria-label="Favorit"
             title="Favorit"
@@ -107,7 +104,11 @@ export default function TagButton({
             onClick={handleRemove}
             aria-label="Entfernen"
           >
-            <X className="w-3 h-3 text-gray-700 ml-1" />
+            <X
+              className={`w-3 h-3 ml-1 ${
+                variant === TagContext.Selected ? 'text-white' : 'text-gray-700'
+              }`}
+            />
           </button>
         )}
       </div>

--- a/src/components/TagSelectorWithFavorites.tsx
+++ b/src/components/TagSelectorWithFavorites.tsx
@@ -141,7 +141,7 @@ export default function TagSelectorWithFavorites({
                 <TagButton
                   key={item}
                   label={item}
-                  variant={TagContext.Favorites}
+                  variant={TagContext.Favorite}
                   isFavorite
                   type="position"
                   onClick={() => addTag(item)}

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -166,7 +166,7 @@ export default function TasksTagInput({
                 <TagButton
                   key={item}
                   label={item}
-                  variant={TagContext.Favorites}
+                  variant={TagContext.Favorite}
                   isFavorite
                   type="task"
                   onClick={() => addTask(item)}

--- a/src/pages/StyleTest.tsx
+++ b/src/pages/StyleTest.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import TagButton from '../components/TagButton';
+import MonthYearPicker from '../components/MonthYearPicker';
+import MonthYearInput from '../components/MonthYearInput';
+import TagContext from '../types/TagContext';
+
+export default function StyleTest() {
+  const [pickerValue, setPickerValue] = useState('');
+  const [inputValue, setInputValue] = useState('');
+
+  return (
+    <div className="p-4 space-y-6">
+      <h2 className="font-bold">TagButton Varianten</h2>
+      <div className="flex gap-2 flex-wrap">
+        <TagButton label="Selected" variant={TagContext.Selected} isFavorite onRemove={() => {}} />
+        <TagButton label="Suggestion" variant={TagContext.Suggestion} isFavorite />
+        <TagButton label="Favorite" variant={TagContext.Favorite} isFavorite onRemove={() => {}} />
+      </div>
+
+      <h2 className="font-bold">MonthYearPicker</h2>
+      <MonthYearPicker value={pickerValue} onChange={setPickerValue} />
+
+      <h2 className="font-bold">MonthYearInput</h2>
+      <MonthYearInput value={inputValue} onChange={setInputValue} />
+    </div>
+  );
+}

--- a/src/types/TagContext.ts
+++ b/src/types/TagContext.ts
@@ -1,7 +1,7 @@
 export enum TagContext {
   Selected = 'selected',
   Suggestion = 'suggestion',
-  Favorites = 'favorites',
+  Favorite = 'favorite',
 }
 
 export default TagContext;


### PR DESCRIPTION
## Summary
- add selected/suggestion/favorite variant for `TagButton`
- split `MonthYearInput` into month and year fields
- tweak UI spacing of `MonthYearPicker`
- add `StyleTest` page with visual UI preview

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68718574e10883259485af47e0415be9