### PR TITLE
UI Reset und Debug Preview

### DIFF
--- a/src/components/CompaniesTagInput.tsx
+++ b/src/components/CompaniesTagInput.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from 'react';
 import CompanyTag from './CompanyTag';
 import TagButton from './TagButton';
+import TagButtonFavorite from './ui/TagButtonFavorite';
 import TagContext from '../types/TagContext';
 import { useLebenslaufContext } from '../context/LebenslaufContext';
 
@@ -82,14 +83,11 @@ export default function CompaniesTagInput({ value, onChange }: CompaniesTagInput
             {favorites
               .filter((f) => !value.includes(f))
               .map((f) => (
-                <TagButton
+                <TagButtonFavorite
                   key={f}
                   label={f}
-                  variant={TagContext.Favorite}
-                  isFavorite
                   onClick={() => addCompany(f)}
                   onRemove={() => toggleFavoriteCompany(f)}
-                  type="company"
                 />
               ))}
           </div>

--- a/src/components/CompanyTag.tsx
+++ b/src/components/CompanyTag.tsx
@@ -1,8 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { X } from 'lucide-react';
 import { useLebenslaufContext } from '../context/LebenslaufContext';
-import TagButton from './TagButton';
-import TagContext from '../types/TagContext';
+import TagButtonSelected from './ui/TagButtonSelected';
 
 interface CompanyTagProps {
   label: string;
@@ -59,12 +58,10 @@ export default function CompanyTag({ label, onRemove, onEdit }: CompanyTagProps)
   }
 
   return (
-    <TagButton
+    <TagButtonSelected
       label={label}
-      variant={TagContext.Selected}
       isFavorite={isFavorite}
-      type="company"
-      onToggleFavorite={toggleFavoriteCompany}
+      onToggleFavorite={() => toggleFavoriteCompany(label)}
       onRemove={onRemove}
       onEdit={() => setEditing(true)}
     />

--- a/src/components/MonthYearInput.tsx
+++ b/src/components/MonthYearInput.tsx
@@ -35,16 +35,14 @@ export default function MonthYearInput({ value = '', onChange }: MonthYearInputP
 
   const emit = (m: string, y: string) => {
     if (!onChange) return;
-    if (m) {
-      if (y) {
-        onChange(`${m}/${y}`);
-      } else if (m.length === 2) {
-        onChange(`${m}/`);
-      } else {
-        onChange(m);
-      }
-    } else {
+    if (m && y) {
+      onChange(`${m}/${y}`);
+    } else if (y) {
       onChange(y);
+    } else if (m) {
+      onChange(m);
+    } else {
+      onChange('');
     }
   };
 
@@ -93,7 +91,6 @@ export default function MonthYearInput({ value = '', onChange }: MonthYearInputP
         inputMode="numeric"
         className={`border rounded w-12 px-1 text-center ${invalid ? 'border-red-500' : 'border-gray-300'}`}
       />
-      <span>/</span>
       <input
         ref={yearRef}
         type="text"

--- a/src/components/MonthYearPicker.tsx
+++ b/src/components/MonthYearPicker.tsx
@@ -211,7 +211,7 @@ export default function MonthYearPicker({
           ref={popupRef}
           className="absolute left-0 mt-1 z-10 bg-white border rounded shadow p-2 w-max"
         >
-          <div className="grid grid-cols-3 gap-x-6">
+          <div className="grid grid-cols-3 gap-x-4">
             <div className="col-span-2 grid grid-cols-2 gap-2 text-sm">
               {months.map((m, i) => (
                 <button

--- a/src/components/PositionTag.tsx
+++ b/src/components/PositionTag.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useLebenslaufContext } from '../context/LebenslaufContext';
-import TagButton from './TagButton';
-import TagContext from '../types/TagContext';
+import TagButtonSelected from './ui/TagButtonSelected';
 
 interface PositionTagProps {
   label: string;
@@ -14,12 +13,10 @@ export default function PositionTag({ label, onRemove, onEdit }: PositionTagProp
   const isFavorite = favoritePositions.includes(label);
 
   return (
-    <TagButton
+    <TagButtonSelected
       label={label}
-      variant={TagContext.Selected}
       isFavorite={isFavorite}
-      type="position"
-      onToggleFavorite={toggleFavoritePosition}
+      onToggleFavorite={() => toggleFavoritePosition(label)}
       onRemove={onRemove}
       onEdit={onEdit}
     />

--- a/src/components/TagSelectorWithFavorites.tsx
+++ b/src/components/TagSelectorWithFavorites.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react';
 import { X } from 'lucide-react';
 import AutocompleteInput from './AutocompleteInput';
 import PositionTag from './PositionTag';
-import TagButton from './TagButton';
-import TagContext from '../types/TagContext';
+import TagButtonFavorite from './ui/TagButtonFavorite';
 import { useLebenslaufContext } from '../context/LebenslaufContext';
 
 interface TagSelectorWithFavoritesProps {
@@ -138,12 +137,9 @@ export default function TagSelectorWithFavorites({
             {favorites
               .filter((item) => !value.includes(item))
               .map((item) => (
-                <TagButton
+                <TagButtonFavorite
                   key={item}
                   label={item}
-                  variant={TagContext.Favorite}
-                  isFavorite
-                  type="position"
                   onClick={() => addTag(item)}
                   onRemove={() => toggleFavorite(item)}
                 />

--- a/src/components/TaskTag.tsx
+++ b/src/components/TaskTag.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useLebenslaufContext } from '../context/LebenslaufContext';
-import TagButton from './TagButton';
-import TagContext from '../types/TagContext';
+import TagButtonSelected from './ui/TagButtonSelected';
 
 interface TaskTagProps {
   label: string;
@@ -14,12 +13,10 @@ export default function TaskTag({ label, onRemove, onEdit }: TaskTagProps) {
   const isFavorite = favoriteTasks.includes(label);
 
   return (
-    <TagButton
+    <TagButtonSelected
       label={label}
-      variant={TagContext.Selected}
       isFavorite={isFavorite}
-      type="task"
-      onToggleFavorite={toggleFavoriteTask}
+      onToggleFavorite={() => toggleFavoriteTask(label)}
       onEdit={onEdit}
       onRemove={onRemove}
     />

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from "react";
 import { Lightbulb, X } from "lucide-react";
 import TaskTag from "./TaskTag";
 import TagButton from "./TagButton";
+import TagButtonFavorite from "./ui/TagButtonFavorite";
 import TagContext from "../types/TagContext";
 import AutocompleteInput from "./AutocompleteInput";
 import { getTasksForPositions } from "../constants/positionsToTasks";
@@ -163,12 +164,9 @@ export default function TasksTagInput({
             {favorites
               .filter((item) => !value.includes(item))
               .map((item) => (
-                <TagButton
+                <TagButtonFavorite
                   key={item}
                   label={item}
-                  variant={TagContext.Favorite}
-                  isFavorite
-                  type="task"
                   onClick={() => addTask(item)}
                   onRemove={() => toggleFavorite(item)}
                 />

--- a/src/components/ui/TagButtonFavorite.tsx
+++ b/src/components/ui/TagButtonFavorite.tsx
@@ -1,0 +1,29 @@
+import { X } from 'lucide-react';
+import IconStar from '../IconStar';
+
+interface TagButtonFavoriteProps {
+  label: string;
+  onClick?: () => void;
+  onRemove?: () => void;
+}
+
+export default function TagButtonFavorite({ label, onClick, onRemove }: TagButtonFavoriteProps) {
+  const handleRemove = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onRemove?.();
+  };
+
+  return (
+    <button type="button" onClick={onClick} className="tag-button-favorite flex justify-between items-center gap-1">
+      <span className="flex items-center gap-1">
+        {label}
+        <IconStar size={16} fill="#FDE047" stroke="#FDE047" />
+      </span>
+      {onRemove && (
+        <button type="button" onClick={handleRemove} aria-label="Entfernen" className="text-gray-600">
+          <X className="w-3 h-3" />
+        </button>
+      )}
+    </button>
+  );
+}

--- a/src/components/ui/TagButtonSelected.tsx
+++ b/src/components/ui/TagButtonSelected.tsx
@@ -1,0 +1,46 @@
+import { X } from 'lucide-react';
+import IconStar from '../IconStar';
+
+interface TagButtonSelectedProps {
+  label: string;
+  isFavorite?: boolean;
+  onToggleFavorite?: () => void;
+  onRemove?: () => void;
+  onEdit?: () => void;
+}
+
+export default function TagButtonSelected({
+  label,
+  isFavorite = false,
+  onToggleFavorite,
+  onRemove,
+  onEdit,
+}: TagButtonSelectedProps) {
+  const handleToggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onToggleFavorite?.();
+  };
+
+  const handleRemove = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onRemove?.();
+  };
+
+  return (
+    <button type="button" onClick={onEdit} className="tag-button-selected flex justify-between items-center gap-1">
+      <span className="flex items-center gap-1">
+        {label}
+        {isFavorite && (
+          <span onClick={handleToggle} className="star-icon" role="button" aria-label="Favorit">
+            <IconStar size={16} fill="#FDE047" stroke="#FDE047" />
+          </span>
+        )}
+      </span>
+      {onRemove && (
+        <button type="button" onClick={handleRemove} aria-label="Entfernen" className="text-white">
+          <X className="w-3 h-3" />
+        </button>
+      )}
+    </button>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,7 @@
 @tailwind utilities;
 
 @import "./styles/_tags.scss";
+@import "./styles/tailwind.css";
 @layer base {
   body {
     font-family: "Roboto", sans-serif;

--- a/src/pages/DebugPreview.tsx
+++ b/src/pages/DebugPreview.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import TagButton from '../components/TagButton';
+import TagButtonFavorite from '../components/ui/TagButtonFavorite';
+import TagButtonSelected from '../components/ui/TagButtonSelected';
+import MonthYearInput from '../components/MonthYearInput';
+import MonthYearPicker from '../components/MonthYearPicker';
+import TagContext from '../types/TagContext';
+
+export default function DebugPreview() {
+  const [pickerValue, setPickerValue] = useState('');
+  const [inputValue, setInputValue] = useState('');
+
+  return (
+    <div className="p-4 space-y-6">
+      <h2 className="font-bold">TagButton Varianten</h2>
+      <div className="flex gap-2 flex-wrap">
+        <TagButtonSelected label="Selected" isFavorite onRemove={() => {}} />
+        <TagButtonFavorite label="Favorite" onRemove={() => {}} />
+        <TagButton label="Suggestion" variant={TagContext.Suggestion} isFavorite />
+      </div>
+
+      <h2 className="font-bold">MonthYearPicker</h2>
+      <MonthYearPicker value={pickerValue} onChange={setPickerValue} />
+
+      <h2 className="font-bold">MonthYearInput</h2>
+      <MonthYearInput value={inputValue} onChange={setInputValue} />
+    </div>
+  );
+}

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,0 +1,11 @@
+@layer components {
+  .tag-button-favorite {
+    @apply bg-[#efefef] text-gray-700 border border-gray-300 rounded-full px-2 py-1;
+  }
+  .tag-button-selected {
+    @apply bg-[#F29400] text-white border border-[#F29400] rounded-full px-3 py-1;
+  }
+  .star-icon {
+    @apply w-4 h-4 flex items-center justify-center text-yellow-400;
+  }
+}


### PR DESCRIPTION
## Summary
- neue TagButtonFavorite und TagButtonSelected Komponenten eingeführt
- Datumseingabe verbessert und validiert
- MonthYearPicker Popup angepasst
- DebugPreview Seite zur UI-Vorschau angelegt

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68718a40dcd883259440acd636455dc0