### PR TITLE
Implement inline tag controls

### DIFF
--- a/src/components/AutocompleteInput.tsx
+++ b/src/components/AutocompleteInput.tsx
@@ -195,49 +195,90 @@ export default function AutocompleteInput({
 
 
   return (
-    <div ref={containerRef} className={`relative ${className} profile-input autocomplete-input`}>
+    <div
+      ref={containerRef}
+      className={`relative ${className} profile-input autocomplete-input`}
+    >
       {label && (
-        <label htmlFor={inputId} className="block text-sm font-medium text-gray-700 mb-1">
+        <label
+          htmlFor={inputId}
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
           {label}
         </label>
       )}
-      <div className="flex space-x-2">
-        <div className="flex-1 relative">
-          <input
-            ref={inputRef}
-            type="text"
-            id={inputId}
-            name={`autocomplete-${inputId}`}
-            value={value}
-            onChange={(e) => onChange(e.target.value)}
-            onKeyDown={handleKeyDown}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            placeholder={placeholder}
-            disabled={disabled}
-            className="w-full px-3 py-2 border rounded-md text-sm focus:outline-none focus:ring-2"
-            style={{
-              borderColor: inputBorderColor,
-              '--tw-ring-color': inputBorderColor
-            } as React.CSSProperties}
-            aria-expanded={isOpen}
-            aria-haspopup="listbox"
-            aria-autocomplete="list"
-            role="combobox"
-          />
-          
-          {/* Dropdown with improved sorting */}
-          {isOpen && filteredSuggestions.length > 0 && (
-            <div 
-              className="absolute top-full left-0 right-0 mt-1 bg-white border rounded-md shadow-lg max-h-48 overflow-y-auto z-50 autocomplete-dropdown" 
-              style={{ borderColor: inputBorderColor }}
-              role="listbox"
-              aria-label="Vorschläge"
-            >
-              {filteredSuggestions.map((suggestion, index) => {
-                const searchTerm = value.toLowerCase();
-                const suggestionLower = suggestion.toLowerCase();
-                const startsWithSearch = suggestionLower.startsWith(searchTerm);
+      <div className="relative">
+        <input
+          ref={inputRef}
+          type="text"
+          id={inputId}
+          name={`autocomplete-${inputId}`}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          placeholder={placeholder}
+          disabled={disabled}
+          className="w-full px-3 py-2 pr-16 border rounded-md text-sm focus:outline-none focus:ring-2 focus:border-orange-500"
+          style={{
+            borderColor: inputBorderColor,
+            '--tw-ring-color': inputBorderColor
+          } as React.CSSProperties}
+          aria-expanded={isOpen}
+          aria-haspopup="listbox"
+          aria-autocomplete="list"
+          role="combobox"
+        />
+
+        {/* Favorites button */}
+        {showFavoritesButton && onAddToFavorites && (
+          <button
+            id={favoritesButtonId}
+            name={`favorites-${inputId}`}
+            onClick={handleAddToFavorites}
+            disabled={disabled || !hasInput}
+            className={`absolute right-8 top-1/2 -translate-y-1/2 w-7 h-7 flex items-center justify-center rounded-md text-white transition-opacity duration-200 hover:shadow ${
+              hasInput ? 'opacity-100' : 'opacity-0 pointer-events-none'
+            }`}
+            style={{ backgroundColor: '#F59E0B' }}
+            title="Zu Favoriten hinzufügen"
+            aria-label="Zu Favoriten hinzufügen"
+          >
+            <Star className="w-4 h-4" />
+          </button>
+        )}
+
+        {/* Add button */}
+        {showAddButton && (
+          <button
+            id={addButtonId}
+            name={`add-${inputId}`}
+            onClick={() => onAdd()}
+            disabled={disabled || !hasInput}
+            className={`absolute right-0 top-1/2 -translate-y-1/2 w-7 h-7 flex items-center justify-center rounded-md text-white transition-opacity duration-200 hover:shadow ${
+              hasInput ? 'opacity-100' : 'opacity-0 pointer-events-none'
+            }`}
+            style={{ backgroundColor: '#F59E0B' }}
+            title="Hinzufügen"
+            aria-label="Hinzufügen"
+          >
+            <Plus className="w-4 h-4" />
+          </button>
+        )}
+
+        {/* Dropdown with improved sorting */}
+        {isOpen && filteredSuggestions.length > 0 && (
+          <div
+            className="absolute top-full left-0 right-0 mt-1 bg-white border rounded-md shadow-lg max-h-48 overflow-y-auto z-50 autocomplete-dropdown"
+            style={{ borderColor: inputBorderColor }}
+            role="listbox"
+            aria-label="Vorschläge"
+          >
+            {filteredSuggestions.map((suggestion, index) => {
+              const searchTerm = value.toLowerCase();
+              const suggestionLower = suggestion.toLowerCase();
+              const startsWithSearch = suggestionLower.startsWith(searchTerm);
                 
                 return (
                   <button
@@ -264,43 +305,7 @@ export default function AutocompleteInput({
               })}
             </div>
           )}
-        </div>
-        
-        {/* Favorites button */}
-        {showFavoritesButton && onAddToFavorites && (
-          <button
-            id={favoritesButtonId}
-            name={`favorites-${inputId}`}
-            onClick={handleAddToFavorites}
-            disabled={disabled || !hasInput}
-            className={`w-7 h-7 flex items-center justify-center rounded-md text-white transition-opacity duration-200 hover:shadow ${
-              hasInput ? 'opacity-100' : 'opacity-0 pointer-events-none'
-            }`}
-            style={{ backgroundColor: '#F59E0B' }}
-            title="Zu Favoriten hinzufügen"
-            aria-label="Zu Favoriten hinzufügen"
-          >
-            <Star className="w-4 h-4" />
-          </button>
-        )}
-        
-        {/* Add button */}
-        {showAddButton && (
-          <button
-            id={addButtonId}
-            name={`add-${inputId}`}
-            onClick={() => onAdd()}
-            disabled={disabled || !hasInput}
-            className={`w-7 h-7 flex items-center justify-center rounded-md text-white transition-opacity duration-200 hover:shadow ${
-              hasInput ? 'opacity-100' : 'opacity-0 pointer-events-none'
-            }`}
-            style={{ backgroundColor: '#F59E0B' }}
-            title="Hinzufügen"
-            aria-label="Hinzufügen"
-          >
-            <Plus className="w-4 h-4" />
-          </button>
-        )}
       </div>
     </div>
-  );}
+  );
+}

--- a/src/components/CompaniesTagInput.tsx
+++ b/src/components/CompaniesTagInput.tsx
@@ -1,7 +1,8 @@
-import { useState, useRef } from 'react';
+import { useState } from 'react';
 import CompanyTag from './CompanyTag';
 import TagButtonFavorite from './ui/TagButtonFavorite';
 import { useLebenslaufContext } from '../context/LebenslaufContext';
+import AutocompleteInput from './AutocompleteInput';
 
 interface CompaniesTagInputProps {
   value: string[];
@@ -10,7 +11,6 @@ interface CompaniesTagInputProps {
 
 export default function CompaniesTagInput({ value, onChange }: CompaniesTagInputProps) {
   const [inputValue, setInputValue] = useState('');
-  const inputRef = useRef<HTMLInputElement>(null);
   const { favoriteCompanies: favorites, toggleFavoriteCompany } =
     useLebenslaufContext();
 
@@ -29,15 +29,8 @@ export default function CompaniesTagInput({ value, onChange }: CompaniesTagInput
     onChange(value.map((v) => (v === oldVal ? newVal : v)));
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' || e.key === ',') {
-      e.preventDefault();
-      addCompany();
-    }
-  };
-
-  const handleAddFavorite = () => {
-    const trimmed = inputValue.trim();
+  const handleAddFavoriteInput = (val?: string) => {
+    const trimmed = (val ?? inputValue).trim();
     if (!trimmed) return;
     toggleFavoriteCompany(trimmed);
     setInputValue('');
@@ -45,31 +38,17 @@ export default function CompaniesTagInput({ value, onChange }: CompaniesTagInput
 
   return (
     <div className="space-y-2">
-      <div className="flex space-x-1">
-        <input
-          ref={inputRef}
-          type="text"
-          placeholder="Firma hinzufügen..."
-          className="flex-1 px-3 py-2 border rounded"
-          value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
-          onKeyDown={handleKeyDown}
-        />
-        <button
-          onClick={() => addCompany()}
-          className="px-3 py-2 rounded text-white bg-yellow-400"
-          aria-label="Hinzufügen"
-        >
-          +
-        </button>
-        <button
-          onClick={handleAddFavorite}
-          className="px-2 py-1 rounded text-white bg-yellow-300 text-sm"
-          aria-label="Als Favorit hinzufügen"
-        >
-          ★
-        </button>
-      </div>
+      <AutocompleteInput
+        value={inputValue}
+        onChange={setInputValue}
+        onAdd={addCompany}
+        onAddToFavorites={handleAddFavoriteInput}
+        suggestions={[]}
+        placeholder="Firma hinzufügen..."
+        inputBorderColor="#D1D5DB"
+        showAddButton
+        showFavoritesButton
+      />
       {value.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {value.map((c) => (

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -64,6 +64,13 @@ export default function TasksTagInput({
     toggleFavoriteTask(task);
   };
 
+  const handleAddFavoriteInput = (val?: string) => {
+    const toAdd = (val ?? inputValue).trim();
+    if (!toAdd) return;
+    toggleFavorite(toAdd);
+    setInputValue("");
+  };
+
 
   return (
     <div className="space-y-4">
@@ -72,12 +79,13 @@ export default function TasksTagInput({
         value={inputValue}
         onChange={setInputValue}
         onAdd={addTask}
+        onAddToFavorites={handleAddFavoriteInput}
         suggestions={filteredSuggestions}
         placeholder="Hinzufügen..."
         buttonColor="orange"
         inputBorderColor="#D1D5DB"
-        showFavoritesButton={false}
-        showAddButton={false}
+        showFavoritesButton
+        showAddButton
       />
 
       {value.length > 0 && (


### PR DESCRIPTION
## Summary
- add inline add & favorite buttons inside `AutocompleteInput`
- refactor `CompaniesTagInput` to use `AutocompleteInput`
- enable inline controls for `TasksTagInput`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68722d3bc4c48325bbb74f681bdd6ab7