### PR TITLE
Add InputWithActions and refactor tag inputs

### DIFF
--- a/src/components/CompaniesTagInput.tsx
+++ b/src/components/CompaniesTagInput.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import CompanyTag from './CompanyTag';
 import TagButtonFavorite from './ui/TagButtonFavorite';
 import { useLebenslaufContext } from '../context/LebenslaufContext';
-import AutocompleteInput from './AutocompleteInput';
+import InputWithActions from './InputWithActions';
 
 interface CompaniesTagInputProps {
   value: string[];
@@ -38,16 +38,12 @@ export default function CompaniesTagInput({ value, onChange }: CompaniesTagInput
 
   return (
     <div className="space-y-2">
-      <AutocompleteInput
+      <InputWithActions
         value={inputValue}
         onChange={setInputValue}
         onAdd={addCompany}
-        onAddToFavorites={handleAddFavoriteInput}
-        suggestions={[]}
+        onAddFavorite={handleAddFavoriteInput}
         placeholder="Firma hinzufügen..."
-        inputBorderColor="#D1D5DB"
-        showAddButton
-        showFavoritesButton
       />
       {value.length > 0 && (
         <div className="flex flex-wrap gap-2">

--- a/src/components/InputWithActions.tsx
+++ b/src/components/InputWithActions.tsx
@@ -1,0 +1,71 @@
+import React, { ChangeEvent, KeyboardEvent } from 'react';
+
+interface InputWithActionsProps {
+  value: string;
+  placeholder?: string;
+  onChange: (v: string) => void;
+  onAdd: (v: string) => void;
+  onAddFavorite: (v: string) => void;
+}
+
+export default function InputWithActions({
+  value,
+  placeholder = '',
+  onChange,
+  onAdd,
+  onAddFavorite,
+}: InputWithActionsProps) {
+  const hasValue = value.trim().length > 0;
+
+  const handleAdd = () => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onAdd(trimmed);
+    onChange('');
+  };
+
+  const handleAddFavorite = () => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onAddFavorite(trimmed);
+    onChange('');
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleAdd();
+    }
+  };
+
+  return (
+    <div className="flex w-full">
+      <input
+        type="text"
+        value={value}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        className="flex-1 border rounded-l-md py-2 px-3 transition-all focus:border-[#F29400] focus:outline-none"
+      />
+      {hasValue && (
+        <>
+          <button
+            type="button"
+            onClick={handleAdd}
+            className="h-[42px] bg-[#F6A800] text-white px-3 rounded-md hover:opacity-90"
+          >
+            +
+          </button>
+          <button
+            type="button"
+            onClick={handleAddFavorite}
+            className="h-[42px] bg-[#F6A800] text-white px-3 rounded-md hover:opacity-90 ml-1"
+          >
+            ★
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -4,7 +4,7 @@ import TaskTag from "./TaskTag";
 import TagButton from "./TagButton";
 import TagButtonFavorite from "./ui/TagButtonFavorite";
 import TagContext from "../types/TagContext";
-import AutocompleteInput from "./AutocompleteInput";
+import InputWithActions from "./InputWithActions";
 import { getTasksForPositions } from "../constants/positionsToTasks";
 import { useLebenslaufContext } from "../context/LebenslaufContext";
 import "../styles/_tags.scss";
@@ -75,17 +75,12 @@ export default function TasksTagInput({
   return (
     <div className="space-y-4">
 
-      <AutocompleteInput
+      <InputWithActions
         value={inputValue}
         onChange={setInputValue}
         onAdd={addTask}
-        onAddToFavorites={handleAddFavoriteInput}
-        suggestions={filteredSuggestions}
+        onAddFavorite={handleAddFavoriteInput}
         placeholder="Hinzufügen..."
-        buttonColor="orange"
-        inputBorderColor="#D1D5DB"
-        showFavoritesButton
-        showAddButton
       />
 
       {value.length > 0 && (


### PR DESCRIPTION
## Summary
- add reusable `InputWithActions` component for adding tags with favorite button
- use `InputWithActions` in `CompaniesTagInput` and `TasksTagInput`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872352ae3288325bc1acea226299dbd