### PR TITLE
Integrate Supabase CRUD for experiences

### DIFF
--- a/src/components/LebenslaufInput.tsx
+++ b/src/components/LebenslaufInput.tsx
@@ -57,16 +57,16 @@ export default function LebenslaufInput() {
     setForm((prev) => ({ ...prev, [field]: value }));
   };
 
-  const handleAdd = () => {
-    addExperience(form);
+  const handleAdd = async () => {
+    await addExperience(form);
     setForm(initialExperience);
     setSelectedPositions([]);
     selectExperience(null);
   };
 
-  const handleUpdate = () => {
+  const handleUpdate = async () => {
     if (selectedExperienceId !== null) {
-      updateExperience(selectedExperienceId, form);
+      await updateExperience(selectedExperienceId, form);
     }
     setForm(initialExperience);
     setSelectedPositions([]);

--- a/src/services/supabaseService.ts
+++ b/src/services/supabaseService.ts
@@ -1,5 +1,6 @@
 import { supabase } from '../lib/supabase';
 import { KIModelSettings } from '../types/KIModelSettings';
+import { ExperienceEntry } from '../types/ExperienceType';
 
 // --- Types --------------------------------------------------------------
 export interface ProfileConfig {
@@ -231,6 +232,48 @@ async function testSupabaseConnection(): Promise<boolean> {
   return true;
 }
 
+// -----------------------------------------------------------------------
+// Lebenslauf-Experiences CRUD
+async function fetchExperiences(userId: string): Promise<ExperienceEntry[]> {
+  const { data, error } = await supabase
+    .from('experiences')
+    .select('*')
+    .eq('user_id', userId)
+    .order('startYear', { ascending: false })
+    .order('startMonth', { ascending: false });
+
+  if (error) {
+    console.error('Error fetching experiences:', error.message);
+    return [];
+  }
+
+  return (data ?? []) as ExperienceEntry[];
+}
+
+async function upsertExperience(
+  experience: ExperienceEntry & { user_id?: string },
+): Promise<ExperienceEntry | null> {
+  const { data, error } = await supabase
+    .from('experiences')
+    .upsert(experience)
+    .select()
+    .single();
+
+  if (error) {
+    console.error('Error saving experience:', error.message);
+    return null;
+  }
+
+  return data as ExperienceEntry;
+}
+
+async function deleteExperience(id: string): Promise<void> {
+  const { error } = await supabase.from('experiences').delete().eq('id', id);
+  if (error) {
+    console.error('Error deleting experience:', error.message);
+  }
+}
+
 async function fetchTableColumns(tableName: string): Promise<string[]> {
   const { data, error } = await supabase
     .from('available_columns')
@@ -252,6 +295,9 @@ export {
   isSupabaseConfigured,
   loadProfileSuggestions,
   testSupabaseConnection,
+  fetchExperiences,
+  upsertExperience,
+  deleteExperience,
   fetchTableColumns,
   getSupabaseTableNames,
   invalidateTableCache,


### PR DESCRIPTION
## Summary
- add Supabase CRUD helpers in `supabaseService`
- load experiences from Supabase in `LebenslaufContext`
- persist experiences to Supabase on add/update
- adjust `LebenslaufInput` to await async context methods

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6872972c28308325995a0fa37f5f4923