### PR TITLE
Add CV suggestion loading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -537,7 +537,7 @@ function HomePage() {
 
         {activeTab === 'lebenslauf' && (
           <div className="p-6">
-            <LebenslaufEditor />
+            <LebenslaufEditor profileSourceMappings={profileSourceMappings} />
           </div>
         )}
 

--- a/src/components/CompaniesTagInput.tsx
+++ b/src/components/CompaniesTagInput.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import CompanyTag from './CompanyTag';
 import TagButtonFavorite from './ui/TagButtonFavorite';
+import TagButton from './TagButton';
+import TagContext from '../types/TagContext';
 import { useLebenslaufContext } from '../context/LebenslaufContext';
 import TextInputWithButtons from './TextInputWithButtons';
 import { useTagList } from '../hooks/useTagList';
@@ -8,9 +10,10 @@ import { useTagList } from '../hooks/useTagList';
 interface CompaniesTagInputProps {
   value: string[];
   onChange: (companies: string[]) => void;
+  suggestions?: string[];
 }
 
-export default function CompaniesTagInput({ value, onChange }: CompaniesTagInputProps) {
+export default function CompaniesTagInput({ value, onChange, suggestions = [] }: CompaniesTagInputProps) {
   const [inputValue, setInputValue] = useState('');
   const { favoriteCompanies: favorites, toggleFavoriteCompany } =
     useLebenslaufContext();
@@ -43,6 +46,8 @@ export default function CompaniesTagInput({ value, onChange }: CompaniesTagInput
     setInputValue('');
   };
 
+  const filteredSuggestions = suggestions.filter((s) => !value.includes(s));
+
   return (
     <div className="space-y-2">
       <TextInputWithButtons
@@ -62,6 +67,22 @@ export default function CompaniesTagInput({ value, onChange }: CompaniesTagInput
               onEdit={(val) => updateCompany(c, val)}
             />
           ))}
+        </div>
+      )}
+
+      {filteredSuggestions.length > 0 && (
+        <div>
+          <h4 className="text-sm font-medium text-gray-700 mb-2">Vorschläge:</h4>
+          <div className="flex flex-wrap gap-2">
+            {filteredSuggestions.map((s) => (
+              <TagButton
+                key={s}
+                label={s}
+                variant={TagContext.Suggestion}
+                onClick={() => addCompany(s)}
+              />
+            ))}
+          </div>
         </div>
       )}
 

--- a/src/components/ExperienceForm.tsx
+++ b/src/components/ExperienceForm.tsx
@@ -3,12 +3,14 @@ import ZeitraumPicker from './ZeitraumPicker';
 import TasksTagInput from './TasksTagInput';
 import CompaniesTagInput from './CompaniesTagInput';
 import { Berufserfahrung } from '../context/LebenslaufContext';
+import { CVSuggestionConfig } from '../services/supabaseService';
 
 interface ExperienceFormProps {
   form: Omit<Berufserfahrung, 'id'>;
   selectedPositions: string[];
   onUpdateField: <K extends keyof Omit<Berufserfahrung, 'id'>>(field: K, value: Omit<Berufserfahrung, 'id'>[K]) => void;
   onPositionsChange: (val: string[]) => void;
+  cvSuggestions: CVSuggestionConfig;
 }
 
 export default function ExperienceForm({
@@ -16,6 +18,7 @@ export default function ExperienceForm({
   selectedPositions,
   onUpdateField,
   onPositionsChange,
+  cvSuggestions,
 }: ExperienceFormProps) {
   return (
     <div className="space-y-4">
@@ -60,6 +63,7 @@ export default function ExperienceForm({
         <CompaniesTagInput
           value={form.companies}
           onChange={(val) => onUpdateField('companies', val)}
+          suggestions={cvSuggestions.companies}
         />
       </div>
 
@@ -71,8 +75,8 @@ export default function ExperienceForm({
             onPositionsChange(val);
             onUpdateField('position', val);
           }}
-          options={[]}
           allowCustom={true}
+          suggestions={cvSuggestions.positions}
         />
       </div>
 
@@ -82,6 +86,7 @@ export default function ExperienceForm({
           value={form.aufgabenbereiche}
           onChange={(val) => onUpdateField('aufgabenbereiche', val)}
           positionen={selectedPositions}
+          suggestions={cvSuggestions.aufgabenbereiche}
         />
       </div>
     </div>

--- a/src/components/LebenslaufEditor.tsx
+++ b/src/components/LebenslaufEditor.tsx
@@ -1,11 +1,16 @@
 import React from "react";
 import { LebenslaufProvider } from "../context/LebenslaufContext";
+import { ProfileSourceMapping } from "../services/supabaseService";
 import LebenslaufInput from "./LebenslaufInput";
 import LebenslaufPreview from "./LebenslaufPreview";
 
-export default function LebenslaufEditor() {
+export default function LebenslaufEditor({
+  profileSourceMappings = [],
+}: {
+  profileSourceMappings?: ProfileSourceMapping[];
+}) {
   return (
-    <LebenslaufProvider>
+    <LebenslaufProvider profileSourceMappings={profileSourceMappings}>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Linke Spalte: Eingabe */}
         <div className="bg-white p-6 rounded-lg shadow border border-gray-200">

--- a/src/components/LebenslaufInput.tsx
+++ b/src/components/LebenslaufInput.tsx
@@ -27,6 +27,7 @@ export default function LebenslaufInput() {
     addExperience,
     updateExperience,
     selectExperience,
+    cvSuggestions,
   } = useLebenslaufContext();
 
   const [form, setForm] = useState<BerufserfahrungForm>(initialExperience);
@@ -81,6 +82,7 @@ export default function LebenslaufInput() {
           selectedPositions={selectedPositions}
           onUpdateField={updateField}
           onPositionsChange={setSelectedPositions}
+          cvSuggestions={cvSuggestions}
         />
         <button
           className={`w-full border border-gray-300 bg-gray-50 text-gray-700 font-medium py-2 px-4 rounded-md hover:bg-gray-100 transition`}

--- a/src/components/ProfileSourceSettings.tsx
+++ b/src/components/ProfileSourceSettings.tsx
@@ -20,7 +20,10 @@ const CATEGORY_LABELS = {
   taetigkeiten: 'Tätigkeiten',
   skills: 'Fachliche Kompetenzen',
   softskills: 'Persönliche Kompetenzen',
-  ausbildung: 'Ausbildung/Qualifikationen'
+  ausbildung: 'Ausbildung/Qualifikationen',
+  companies: 'Firmen',
+  positions: 'Positionen',
+  aufgabenbereiche: 'Aufgabenbereiche'
 };
 
 function ProfileSourceSettings({

--- a/src/components/TagSelectorWithFavorites.tsx
+++ b/src/components/TagSelectorWithFavorites.tsx
@@ -9,16 +9,18 @@ interface TagSelectorWithFavoritesProps {
   label: string;
   value: string[];
   onChange: (val: string[]) => void;
-  options: string[];
+  options?: string[];
   allowCustom: boolean;
+  suggestions?: string[];
 }
 
 export default function TagSelectorWithFavorites({
   label,
   value,
   onChange,
-  options,
+  options = [],
   allowCustom,
+  suggestions,
 }: TagSelectorWithFavoritesProps) {
   const [inputValue, setInputValue] = useState('');
   const [editIndex, setEditIndex] = useState<number | null>(null);
@@ -29,7 +31,8 @@ export default function TagSelectorWithFavorites({
   const addTag = (tag: string) => {
     const trimmed = tag.trim();
     if (!trimmed) return;
-    if (!allowCustom && !options.includes(trimmed)) return;
+    const opts = suggestions ?? options;
+    if (!allowCustom && !opts.includes(trimmed)) return;
     if (value.includes(trimmed)) return;
     onChange([...value, trimmed]);
   };
@@ -77,7 +80,7 @@ export default function TagSelectorWithFavorites({
         onChange={setInputValue}
         onAdd={handleAddInput}
         onFavoriteClick={handleAddFavoriteInput}
-        suggestions={options}
+        suggestions={suggestions ?? options}
         placeholder="Hinzufügen..."
         showFavoritesButton
         showAddButton

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -14,12 +14,14 @@ interface TasksTagInputProps {
   value: string[];
   onChange: (tasks: string[]) => void;
   positionen: string[];
+  suggestions?: string[];
 }
 
 export default function TasksTagInput({
   value,
   onChange,
   positionen,
+  suggestions: extraSuggestions,
 }: TasksTagInputProps) {
   const [inputValue, setInputValue] = useState("");
   const [editIndex, setEditIndex] = useState<number | null>(null);
@@ -33,11 +35,16 @@ export default function TasksTagInput({
   });
 
   const suggestions = useMemo(() => {
+    if (extraSuggestions && extraSuggestions.length > 0) {
+      const uniq = Array.from(new Set(extraSuggestions));
+      uniq.sort((a, b) => a.localeCompare(b, "de", { sensitivity: "base" }));
+      return uniq;
+    }
     const fromPositions = getTasksForPositions(positionen);
     const unique = Array.from(new Set(fromPositions));
     unique.sort((a, b) => a.localeCompare(b, "de", { sensitivity: "base" }));
     return unique;
-  }, [positionen]);
+  }, [positionen, extraSuggestions]);
 
   const filteredSuggestions = suggestions.filter((s) => !value.includes(s));
 

--- a/src/context/LebenslaufContext.tsx
+++ b/src/context/LebenslaufContext.tsx
@@ -3,8 +3,14 @@ import React, {
   useContext,
   useState,
   ReactNode,
+  useEffect,
 } from 'react';
 import { v4 as uuidv4 } from 'uuid';
+import {
+  CVSuggestionConfig,
+  loadCVSuggestions,
+  ProfileSourceMapping,
+} from '../services/supabaseService';
 
 export interface Berufserfahrung {
   id: string;
@@ -31,11 +37,18 @@ interface LebenslaufContextType {
   toggleFavoritePosition: (pos: string) => void;
   toggleFavoriteTask: (task: string) => void;
   toggleFavoriteCompany: (company: string) => void;
+  cvSuggestions: CVSuggestionConfig;
 }
 
 const LebenslaufContext = createContext<LebenslaufContextType | undefined>(undefined);
 
-export function LebenslaufProvider({ children }: { children: ReactNode }) {
+export function LebenslaufProvider({
+  children,
+  profileSourceMappings = [],
+}: {
+  children: ReactNode;
+  profileSourceMappings?: ProfileSourceMapping[];
+}) {
   const LOCAL_KEY = 'berufserfahrungen';
 
   const [berufserfahrungen, setBerufserfahrungen] = useState<Berufserfahrung[]>(() => {
@@ -52,6 +65,17 @@ export function LebenslaufProvider({ children }: { children: ReactNode }) {
   const [favoritePositions, setFavoritePositions] = useState<string[]>([]);
   const [favoriteTasks, setFavoriteTasks] = useState<string[]>([]);
   const [favoriteCompanies, setFavoriteCompanies] = useState<string[]>([]);
+  const [cvSuggestions, setCvSuggestions] = useState<CVSuggestionConfig>({
+    companies: [],
+    positions: [],
+    aufgabenbereiche: [],
+  });
+
+  useEffect(() => {
+    if (profileSourceMappings?.length > 0) {
+      loadCVSuggestions(profileSourceMappings).then(setCvSuggestions);
+    }
+  }, [profileSourceMappings]);
 
 
   const addExperience = async (data: Omit<Berufserfahrung, 'id'>) => {
@@ -114,6 +138,7 @@ export function LebenslaufProvider({ children }: { children: ReactNode }) {
         toggleFavoritePosition,
         toggleFavoriteTask,
         toggleFavoriteCompany,
+        cvSuggestions,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- extend profile source categories for CV suggestion fields
- add new CVSuggestionConfig and loader in supabase service
- expose cvSuggestions via LebenslaufContext
- pass profileSourceMappings from App into LebenslaufProvider
- support optional suggestions in company/position/task inputs
- update labels in ProfileSourceSettings

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872a35aaea483259edef1e9bfa3f36f