### PR TITLE
Add CV editor card components

### DIFF
--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+interface DropdownProps {
+  label: string;
+  options: string[];
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export default function Dropdown({ label, options, value, onChange }: DropdownProps) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-700 mb-1">{label}</label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2"
+        style={{ borderColor: '#F29400', '--tw-ring-color': '#F29400' } as React.CSSProperties}
+      >
+        {options.map((opt) => (
+          <option key={opt} value={opt}>
+            {opt}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/components/cards/AusbildungCard.tsx
+++ b/src/components/cards/AusbildungCard.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import Card from './Card';
+import TextInput from '../TextInput';
+import MonthYearInputBase from '../MonthYearInputBase';
+
+interface AusbildungData {
+  institution: string;
+  abschluss: string;
+  start: string;
+  ende: string;
+  beschreibung: string;
+}
+
+interface AusbildungCardProps {
+  data: AusbildungData;
+  onChange: (data: AusbildungData) => void;
+  onDelete?: () => void;
+}
+
+export default function AusbildungCard({ data, onChange }: AusbildungCardProps) {
+  return (
+    <Card title="Ausbildung / Qualifikation">
+      <TextInput
+        label="Institution"
+        value={data.institution}
+        onChange={(v) => onChange({ ...data, institution: v })}
+        placeholder="Institution"
+        rows={2}
+      />
+      <TextInput
+        label="Abschluss"
+        value={data.abschluss}
+        onChange={(v) => onChange({ ...data, abschluss: v })}
+        placeholder="Abschluss"
+        rows={2}
+      />
+      <div className="flex space-x-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Start</label>
+          <MonthYearInputBase
+            value={data.start}
+            onChange={(v) => onChange({ ...data, start: v })}
+            className="w-28"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Ende</label>
+          <MonthYearInputBase
+            value={data.ende}
+            onChange={(v) => onChange({ ...data, ende: v })}
+            className="w-28"
+          />
+        </div>
+      </div>
+      <TextInput
+        label="Beschreibung"
+        value={data.beschreibung}
+        onChange={(v) => onChange({ ...data, beschreibung: v })}
+        placeholder="Beschreibung"
+        rows={4}
+      />
+    </Card>
+  );
+}

--- a/src/components/cards/Card.tsx
+++ b/src/components/cards/Card.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface CardProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+export default function Card({ title, children }: CardProps) {
+  return (
+    <div className="bg-white border border-gray-200 rounded shadow-sm p-4 space-y-4">
+      <h3 className="text-sm font-medium text-gray-700">{title}</h3>
+      {children}
+    </div>
+  );
+}

--- a/src/components/cards/FachkompetenzCard.tsx
+++ b/src/components/cards/FachkompetenzCard.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import Card from './Card';
+import Dropdown from '../Dropdown';
+import TagSelectorWithFavorites from '../TagSelectorWithFavorites';
+
+const KATEGORIEN = ['Programmiersprachen', 'Frameworks', 'Tools'];
+
+interface FachkompetenzData {
+  kategorie: string;
+  kompetenzen: string[];
+  level?: string;
+}
+
+interface FachkompetenzCardProps {
+  data: FachkompetenzData;
+  onChange: (data: FachkompetenzData) => void;
+}
+
+export default function FachkompetenzCard({ data, onChange }: FachkompetenzCardProps) {
+  return (
+    <Card title="Fachliche Kompetenz">
+      <Dropdown
+        label="Kategorie"
+        options={KATEGORIEN}
+        value={data.kategorie}
+        onChange={(v) => onChange({ ...data, kategorie: v })}
+      />
+      <TagSelectorWithFavorites
+        label="Kompetenz"
+        value={data.kompetenzen}
+        onChange={(tags) => onChange({ ...data, kompetenzen: tags })}
+        allowCustom
+      />
+      <Dropdown
+        label="Level"
+        options={['Anfänger', 'Fortgeschritten', 'Experte']}
+        value={data.level ?? ''}
+        onChange={(v) => onChange({ ...data, level: v })}
+      />
+    </Card>
+  );
+}

--- a/src/components/cards/SoftskillCard.tsx
+++ b/src/components/cards/SoftskillCard.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Card from './Card';
+import TextInput from '../TextInput';
+import TagSelectorWithFavorites from '../TagSelectorWithFavorites';
+
+interface SoftskillData {
+  text: string;
+  bisTags: string[];
+}
+
+interface SoftskillCardProps {
+  data: SoftskillData;
+  onChange: (data: SoftskillData) => void;
+}
+
+export default function SoftskillCard({ data, onChange }: SoftskillCardProps) {
+  return (
+    <Card title="Persönliche Kompetenz">
+      <TextInput
+        label="Beschreibung"
+        value={data.text}
+        onChange={(v) => onChange({ ...data, text: v })}
+        placeholder="Beschreibung"
+        rows={4}
+      />
+      <TagSelectorWithFavorites
+        label="BIS-Zuordnung"
+        value={data.bisTags}
+        onChange={(tags) => onChange({ ...data, bisTags: tags })}
+        allowCustom
+      />
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add a generic `Card` component and simple `Dropdown`
- implement `AusbildungCard`, `FachkompetenzCard`, and `SoftskillCard`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872b3729d288325a5b3a942e8d77863