### PR TITLE
Add CV section cards to resume editor

### DIFF
--- a/src/components/CVSection.tsx
+++ b/src/components/CVSection.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+
+interface CVSectionProps {
+  title: string;
+  icon: string;
+  children: React.ReactNode;
+}
+
+export default function CVSection({ title, icon, children }: CVSectionProps) {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <section className="border border-gray-200 rounded-lg overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setIsOpen(prev => !prev)}
+        className="w-full px-4 py-3 bg-gray-50 hover:bg-gray-100 flex items-center justify-between transition-colors duration-200"
+        aria-expanded={isOpen}
+      >
+        <div className="flex items-center space-x-2">
+          <span className="text-base">{icon}</span>
+          <h2 className="font-medium text-gray-900 text-sm">{title}</h2>
+        </div>
+        {isOpen ? (
+          <ChevronUp className="h-5 w-5" style={{ color: '#F29400' }} />
+        ) : (
+          <ChevronDown className="h-5 w-5" style={{ color: '#F29400' }} />
+        )}
+      </button>
+      {isOpen && <div className="p-4 space-y-4 bg-gray-50">{children}</div>}
+    </section>
+  );
+}

--- a/src/components/LebenslaufInput.tsx
+++ b/src/components/LebenslaufInput.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import ExperienceForm from './ExperienceForm';
 import ExperienceSection from './ExperienceSection';
+import CVSection from './CVSection';
+import AusbildungCard from './cards/AusbildungCard';
+import FachkompetenzCard from './cards/FachkompetenzCard';
+import SoftskillCard from './cards/SoftskillCard';
 import {
   Berufserfahrung,
   useLebenslaufContext,
@@ -19,14 +23,45 @@ const initialExperience: BerufserfahrungForm = {
   aufgabenbereiche: [],
 };
 
+const initialEducation = {
+  institution: "",
+  abschluss: "",
+  start: "",
+  ende: "",
+  beschreibung: "",
+};
+
+const initialSkill = {
+  kategorie: "",
+  kompetenzen: [] as string[],
+  level: "",
+};
+
+const initialSoftskill = {
+  text: "",
+  bisTags: [] as string[],
+};
+
 export default function LebenslaufInput() {
   const {
     berufserfahrungen,
+    ausbildungen,
+    fachkompetenzen,
+    softskills,
     selectedExperienceId,
     isEditingExperience,
     addExperience,
     updateExperience,
     selectExperience,
+    addEducation,
+    updateEducation,
+    deleteEducation,
+    addSkill,
+    updateSkill,
+    deleteSkill,
+    addSoftskill,
+    updateSoftskill,
+    deleteSoftskill,
     cvSuggestions,
   } = useLebenslaufContext();
 
@@ -91,6 +126,75 @@ export default function LebenslaufInput() {
           {isEditingExperience ? 'Aktualisieren' : 'Hinzufügen'}
         </button>
       </ExperienceSection>
+
+      <CVSection title="Ausbildung" icon="🎓">
+        {ausbildungen.map((entry) => (
+          <div key={entry.id} className="space-y-2">
+            <AusbildungCard
+              data={entry}
+              onChange={(data) => updateEducation(entry.id, data)}
+            />
+            <button
+              className="text-red-600 text-sm"
+              onClick={() => deleteEducation(entry.id)}
+            >
+              Entfernen
+            </button>
+          </div>
+        ))}
+        <button
+          className="w-full border border-gray-300 bg-gray-50 text-gray-700 font-medium py-2 px-4 rounded-md hover:bg-gray-100 transition"
+          onClick={() => addEducation(initialEducation)}
+        >
+          Neue Ausbildung hinzufügen
+        </button>
+      </CVSection>
+
+      <CVSection title="Fachkompetenz" icon="🛠️">
+        {fachkompetenzen.map((entry) => (
+          <div key={entry.id} className="space-y-2">
+            <FachkompetenzCard
+              data={entry}
+              onChange={(data) => updateSkill(entry.id, data)}
+            />
+            <button
+              className="text-red-600 text-sm"
+              onClick={() => deleteSkill(entry.id)}
+            >
+              Entfernen
+            </button>
+          </div>
+        ))}
+        <button
+          className="w-full border border-gray-300 bg-gray-50 text-gray-700 font-medium py-2 px-4 rounded-md hover:bg-gray-100 transition"
+          onClick={() => addSkill(initialSkill)}
+        >
+          Neue Fachkompetenz hinzufügen
+        </button>
+      </CVSection>
+
+      <CVSection title="Softskills" icon="🌟">
+        {softskills.map((entry) => (
+          <div key={entry.id} className="space-y-2">
+            <SoftskillCard
+              data={entry}
+              onChange={(data) => updateSoftskill(entry.id, data)}
+            />
+            <button
+              className="text-red-600 text-sm"
+              onClick={() => deleteSoftskill(entry.id)}
+            >
+              Entfernen
+            </button>
+          </div>
+        ))}
+        <button
+          className="w-full border border-gray-300 bg-gray-50 text-gray-700 font-medium py-2 px-4 rounded-md hover:bg-gray-100 transition"
+          onClick={() => addSoftskill(initialSoftskill)}
+        >
+          Neue Softskill hinzufügen
+        </button>
+      </CVSection>
     </div>
   );
 }

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -1,11 +1,8 @@
-import React, { useMemo, useState } from "react";
-import { Lightbulb, X } from "lucide-react";
+import React, { useState } from "react";
+import { X } from "lucide-react";
 import TaskTag from "./TaskTag";
-import TagButton from "./TagButton";
 import TagButtonFavorite from "./ui/TagButtonFavorite";
-import TagContext from "../types/TagContext";
 import TextInputWithButtons from "./TextInputWithButtons";
-import { getTasksForPositions } from "../constants/positionsToTasks";
 import { useLebenslaufContext } from "../context/LebenslaufContext";
 import { useTagList } from "../hooks/useTagList";
 import "../styles/_tags.scss";
@@ -13,16 +10,9 @@ import "../styles/_tags.scss";
 interface TasksTagInputProps {
   value: string[];
   onChange: (tasks: string[]) => void;
-  positionen: string[];
-  suggestions?: string[];
 }
 
-export default function TasksTagInput({
-  value,
-  onChange,
-  positionen,
-  suggestions: extraSuggestions,
-}: TasksTagInputProps) {
+export default function TasksTagInput({ value, onChange }: TasksTagInputProps) {
   const [inputValue, setInputValue] = useState("");
   const [editIndex, setEditIndex] = useState<number | null>(null);
   const [editValue, setEditValue] = useState("");
@@ -34,19 +24,6 @@ export default function TasksTagInput({
     allowDuplicates: false
   });
 
-  const suggestions = useMemo(() => {
-    if (extraSuggestions && extraSuggestions.length > 0) {
-      const uniq = Array.from(new Set(extraSuggestions));
-      uniq.sort((a, b) => a.localeCompare(b, "de", { sensitivity: "base" }));
-      return uniq;
-    }
-    const fromPositions = getTasksForPositions(positionen);
-    const unique = Array.from(new Set(fromPositions));
-    unique.sort((a, b) => a.localeCompare(b, "de", { sensitivity: "base" }));
-    return unique;
-  }, [positionen, extraSuggestions]);
-
-  const filteredSuggestions = suggestions.filter((s) => !value.includes(s));
 
   const addTask = (task?: string) => {
     const t = (task ?? inputValue).trim();

--- a/src/context/LebenslaufContext.tsx
+++ b/src/context/LebenslaufContext.tsx
@@ -24,13 +24,47 @@ export interface Berufserfahrung {
   aufgabenbereiche: string[];
 }
 
+export interface AusbildungEntry {
+  id: string;
+  institution: string;
+  abschluss: string;
+  start: string;
+  ende: string;
+  beschreibung: string;
+}
+
+export interface FachkompetenzEntry {
+  id: string;
+  kategorie: string;
+  kompetenzen: string[];
+  level?: string;
+}
+
+export interface SoftskillEntry {
+  id: string;
+  text: string;
+  bisTags: string[];
+}
+
 interface LebenslaufContextType {
   berufserfahrungen: Berufserfahrung[];
+  ausbildungen: AusbildungEntry[];
+  fachkompetenzen: FachkompetenzEntry[];
+  softskills: SoftskillEntry[];
   selectedExperienceId: string | null;
   isEditingExperience: boolean;
   addExperience: (data: Omit<Berufserfahrung, 'id'>) => Promise<void>;
   updateExperience: (id: string, data: Omit<Berufserfahrung, 'id'>) => Promise<void>;
   selectExperience: (id: string | null) => void;
+  addEducation: (data: Omit<AusbildungEntry, 'id'>) => Promise<void>;
+  updateEducation: (id: string, data: Omit<AusbildungEntry, 'id'>) => Promise<void>;
+  deleteEducation: (id: string) => Promise<void>;
+  addSkill: (data: Omit<FachkompetenzEntry, 'id'>) => Promise<void>;
+  updateSkill: (id: string, data: Omit<FachkompetenzEntry, 'id'>) => Promise<void>;
+  deleteSkill: (id: string) => Promise<void>;
+  addSoftskill: (data: Omit<SoftskillEntry, 'id'>) => Promise<void>;
+  updateSoftskill: (id: string, data: Omit<SoftskillEntry, 'id'>) => Promise<void>;
+  deleteSoftskill: (id: string) => Promise<void>;
   favoritePositions: string[];
   favoriteTasks: string[];
   favoriteCompanies: string[];
@@ -50,6 +84,9 @@ export function LebenslaufProvider({
   profileSourceMappings?: ProfileSourceMapping[];
 }) {
   const LOCAL_KEY = 'berufserfahrungen';
+  const LOCAL_EDU_KEY = 'ausbildungen';
+  const LOCAL_SKILL_KEY = 'fachkompetenzen';
+  const LOCAL_SOFT_KEY = 'softskills';
 
   const [berufserfahrungen, setBerufserfahrungen] = useState<Berufserfahrung[]>(() => {
     try {
@@ -57,6 +94,36 @@ export function LebenslaufProvider({
       return saved ? (JSON.parse(saved) as Berufserfahrung[]) : [];
     } catch (err) {
       console.error('Failed to load experiences from localStorage:', err);
+      return [];
+    }
+  });
+
+  const [ausbildungen, setAusbildungen] = useState<AusbildungEntry[]>(() => {
+    try {
+      const saved = localStorage.getItem(LOCAL_EDU_KEY);
+      return saved ? (JSON.parse(saved) as AusbildungEntry[]) : [];
+    } catch (err) {
+      console.error('Failed to load educations from localStorage:', err);
+      return [];
+    }
+  });
+
+  const [fachkompetenzen, setFachkompetenzen] = useState<FachkompetenzEntry[]>(() => {
+    try {
+      const saved = localStorage.getItem(LOCAL_SKILL_KEY);
+      return saved ? (JSON.parse(saved) as FachkompetenzEntry[]) : [];
+    } catch (err) {
+      console.error('Failed to load skills from localStorage:', err);
+      return [];
+    }
+  });
+
+  const [softskills, setSoftskills] = useState<SoftskillEntry[]>(() => {
+    try {
+      const saved = localStorage.getItem(LOCAL_SOFT_KEY);
+      return saved ? (JSON.parse(saved) as SoftskillEntry[]) : [];
+    } catch (err) {
+      console.error('Failed to load softskills from localStorage:', err);
       return [];
     }
   });
@@ -100,6 +167,84 @@ export function LebenslaufProvider({
     setIsEditingExperience(false);
   };
 
+  const addEducation = async (data: Omit<AusbildungEntry, 'id'>) => {
+    const newEntry = { ...data, id: uuidv4() };
+    setAusbildungen(prev => {
+      const updated = [...prev, newEntry];
+      localStorage.setItem(LOCAL_EDU_KEY, JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  const updateEducation = async (id: string, data: Omit<AusbildungEntry, 'id'>) => {
+    const updatedEntry = { ...data, id };
+    setAusbildungen(prev => {
+      const updated = prev.map(e => (e.id === id ? updatedEntry : e));
+      localStorage.setItem(LOCAL_EDU_KEY, JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  const deleteEducation = async (id: string) => {
+    setAusbildungen(prev => {
+      const updated = prev.filter(e => e.id !== id);
+      localStorage.setItem(LOCAL_EDU_KEY, JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  const addSkill = async (data: Omit<FachkompetenzEntry, 'id'>) => {
+    const newEntry = { ...data, id: uuidv4() };
+    setFachkompetenzen(prev => {
+      const updated = [...prev, newEntry];
+      localStorage.setItem(LOCAL_SKILL_KEY, JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  const updateSkill = async (id: string, data: Omit<FachkompetenzEntry, 'id'>) => {
+    const updatedEntry = { ...data, id };
+    setFachkompetenzen(prev => {
+      const updated = prev.map(s => (s.id === id ? updatedEntry : s));
+      localStorage.setItem(LOCAL_SKILL_KEY, JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  const deleteSkill = async (id: string) => {
+    setFachkompetenzen(prev => {
+      const updated = prev.filter(s => s.id !== id);
+      localStorage.setItem(LOCAL_SKILL_KEY, JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  const addSoftskill = async (data: Omit<SoftskillEntry, 'id'>) => {
+    const newEntry = { ...data, id: uuidv4() };
+    setSoftskills(prev => {
+      const updated = [...prev, newEntry];
+      localStorage.setItem(LOCAL_SOFT_KEY, JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  const updateSoftskill = async (id: string, data: Omit<SoftskillEntry, 'id'>) => {
+    const updatedEntry = { ...data, id };
+    setSoftskills(prev => {
+      const updated = prev.map(s => (s.id === id ? updatedEntry : s));
+      localStorage.setItem(LOCAL_SOFT_KEY, JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  const deleteSoftskill = async (id: string) => {
+    setSoftskills(prev => {
+      const updated = prev.filter(s => s.id !== id);
+      localStorage.setItem(LOCAL_SOFT_KEY, JSON.stringify(updated));
+      return updated;
+    });
+  };
+
   const selectExperience = (id: string | null) => {
     setSelectedExperienceId(id);
     setIsEditingExperience(id !== null);
@@ -127,11 +272,23 @@ export function LebenslaufProvider({
     <LebenslaufContext.Provider
       value={{
         berufserfahrungen,
+        ausbildungen,
+        fachkompetenzen,
+        softskills,
         selectedExperienceId,
         isEditingExperience,
         addExperience,
         updateExperience,
         selectExperience,
+        addEducation,
+        updateEducation,
+        deleteEducation,
+        addSkill,
+        updateSkill,
+        deleteSkill,
+        addSoftskill,
+        updateSoftskill,
+        deleteSoftskill,
         favoritePositions,
         favoriteTasks,
         favoriteCompanies,


### PR DESCRIPTION
## Summary
- add generic `CVSection` component for collapsible sections
- extend `LebenslaufContext` with education, skill and softskill handling
- integrate new cards in `LebenslaufInput`
- clean up unused code in `TasksTagInput`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872b5c9353483259ff2c0a3916cd668