### PR TITLE
Add location field to experience section

### DIFF
--- a/src/components/ExperienceForm.tsx
+++ b/src/components/ExperienceForm.tsx
@@ -2,6 +2,7 @@ import TagSelectorWithFavorites from './TagSelectorWithFavorites';
 import ZeitraumPicker from './ZeitraumPicker';
 import TasksTagInput from './TasksTagInput';
 import CompaniesTagInput from './CompaniesTagInput';
+import OrtInput from './OrtInput';
 import { Berufserfahrung } from '../context/LebenslaufContext';
 import { CVSuggestionConfig } from '../services/supabaseService';
 
@@ -60,11 +61,22 @@ export default function ExperienceForm({
 
       <div className="bg-white border border-gray-200 rounded shadow-sm p-4">
         <h3 className="text-sm font-medium text-gray-700 mb-2">Firma</h3>
-        <CompaniesTagInput
-          value={form.companies}
-          onChange={(val) => onUpdateField('companies', val)}
-          suggestions={cvSuggestions.companies}
-        />
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <CompaniesTagInput
+              value={form.companies}
+              onChange={(val) => onUpdateField('companies', val)}
+              suggestions={cvSuggestions.companies}
+            />
+          </div>
+          <div className="w-1/3">
+            <OrtInput
+              value={form.ort}
+              onChange={(val) => onUpdateField('ort', val)}
+              suggestions={cvSuggestions.orte}
+            />
+          </div>
+        </div>
       </div>
 
       <div className="bg-white border border-gray-200 rounded shadow-sm p-4">

--- a/src/components/LebenslaufInput.tsx
+++ b/src/components/LebenslaufInput.tsx
@@ -15,6 +15,7 @@ type BerufserfahrungForm = Omit<Berufserfahrung, "id">;
 const initialExperience: BerufserfahrungForm = {
   companies: [],
   position: [],
+  ort: [],
   startMonth: null,
   startYear: "",
   endMonth: null,

--- a/src/components/LebenslaufPreview.tsx
+++ b/src/components/LebenslaufPreview.tsx
@@ -60,6 +60,9 @@ export default function LebenslaufPreview() {
             {exp.position.join(" / ")}
           </p>
           <p className="italic text-gray-500">{exp.companies.join(', ')}</p>
+          {exp.ort.length > 0 && (
+            <p className="italic text-gray-500">{exp.ort.join(', ')}</p>
+          )}
           <ul className="list-disc list-inside mt-2 space-y-1 text-black">
             {exp.aufgabenbereiche.map((aufgabe, i) => (
               <li key={i}>{aufgabe}</li>

--- a/src/components/OrtInput.tsx
+++ b/src/components/OrtInput.tsx
@@ -1,0 +1,19 @@
+import TagSelectorWithFavorites from './TagSelectorWithFavorites';
+
+interface OrtInputProps {
+  value: string[];
+  onChange: (val: string[]) => void;
+  suggestions?: string[];
+}
+
+export default function OrtInput({ value, onChange, suggestions = [] }: OrtInputProps) {
+  return (
+    <TagSelectorWithFavorites
+      label="Ort"
+      value={value}
+      onChange={onChange}
+      allowCustom={true}
+      suggestions={suggestions}
+    />
+  );
+}

--- a/src/components/ProfileSourceSettings.tsx
+++ b/src/components/ProfileSourceSettings.tsx
@@ -23,7 +23,8 @@ const CATEGORY_LABELS = {
   ausbildung: 'Ausbildung/Qualifikationen',
   companies: 'Firmen',
   positions: 'Positionen',
-  aufgabenbereiche: 'Aufgabenbereiche'
+  aufgabenbereiche: 'Aufgabenbereiche',
+  orte: 'Orte'
 };
 
 function ProfileSourceSettings({

--- a/src/context/LebenslaufContext.tsx
+++ b/src/context/LebenslaufContext.tsx
@@ -22,6 +22,7 @@ export interface Berufserfahrung {
   endYear: string | null;
   isCurrent: boolean;
   aufgabenbereiche: string[];
+  ort: string[];
 }
 
 export interface AusbildungEntry {
@@ -136,6 +137,7 @@ export function LebenslaufProvider({
     companies: [],
     positions: [],
     aufgabenbereiche: [],
+    orte: [],
   });
 
   useEffect(() => {

--- a/src/services/supabaseService.ts
+++ b/src/services/supabaseService.ts
@@ -19,7 +19,8 @@ export interface ProfileSourceMapping {
     | 'ausbildung'
     | 'companies'
     | 'positions'
-    | 'aufgabenbereiche';
+    | 'aufgabenbereiche'
+    | 'orte';
   tableName: string;
   columnName: string;
   isActive: boolean;
@@ -43,6 +44,7 @@ export interface CVSuggestionConfig {
   companies: string[];
   positions: string[];
   aufgabenbereiche: string[];
+  orte: string[];
 }
 
 // -----------------------------------------------------------------------
@@ -265,14 +267,15 @@ export async function loadCVSuggestions(
   mappings: ProfileSourceMapping[]
 ): Promise<CVSuggestionConfig> {
   const relevant = mappings.filter((m) =>
-    ['companies', 'positions', 'aufgabenbereiche'].includes(m.category)
+    ['companies', 'positions', 'aufgabenbereiche', 'orte'].includes(m.category)
   );
 
   const companies = await getSuggestionsFor('companies', relevant);
   const positions = await getSuggestionsFor('positions', relevant);
   const aufgabenbereiche = await getSuggestionsFor('aufgabenbereiche', relevant);
+  const orte = await getSuggestionsFor('orte', relevant);
 
-  return { companies, positions, aufgabenbereiche };
+  return { companies, positions, aufgabenbereiche, orte };
 }
 
 async function testSupabaseConnection(): Promise<boolean> {

--- a/src/types/ExperienceType.ts
+++ b/src/types/ExperienceType.ts
@@ -8,4 +8,5 @@ export interface ExperienceEntry {
   endYear: string | null;
   isCurrent: boolean;
   aufgabenbereiche: string[];
+  ort: string[];
 }


### PR DESCRIPTION
## Summary
- add `OrtInput` component
- support locations in experience form and preview
- extend CV suggestions with "orte"
- update context types and initial form data
- expose new mapping label in profile source settings

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872bc41313083258b08f9c56f252a16