### PR TITLE
Add location input with Supabase suggestions

### DIFF
--- a/src/components/ExperienceForm.tsx
+++ b/src/components/ExperienceForm.tsx
@@ -2,7 +2,7 @@ import TagSelectorWithFavorites from './TagSelectorWithFavorites';
 import ZeitraumPicker from './ZeitraumPicker';
 import TasksTagInput from './TasksTagInput';
 import CompaniesTagInput from './CompaniesTagInput';
-import OrtInput from './OrtInput';
+import LocationInput from './LocationInput';
 import { Berufserfahrung } from '../context/LebenslaufContext';
 import { CVSuggestionConfig } from '../services/supabaseService';
 
@@ -61,16 +61,16 @@ export default function ExperienceForm({
 
       <div className="bg-white border border-gray-200 rounded shadow-sm p-4">
         <h3 className="text-sm font-medium text-gray-700 mb-2">Firma</h3>
-        <div className="flex flex-col md:flex-row gap-2">
-          <div className="w-full md:w-[70%]">
+        <div className="flex flex-wrap gap-2">
+          <div className="w-full md:w-1/2">
             <CompaniesTagInput
               value={form.companies}
               onChange={(val) => onUpdateField('companies', val)}
               suggestions={cvSuggestions.companies}
             />
           </div>
-          <div className="w-full md:w-[30%]">
-            <OrtInput
+          <div className="w-full md:w-1/2">
+            <LocationInput
               value={form.ort}
               onChange={(val) => onUpdateField('ort', val)}
               suggestions={cvSuggestions.orte}

--- a/src/components/LocationInput.tsx
+++ b/src/components/LocationInput.tsx
@@ -1,0 +1,20 @@
+import TagSelectorWithFavorites from './TagSelectorWithFavorites';
+
+interface LocationInputProps {
+  label: string;
+  value: string[];
+  onChange: (val: string[]) => void;
+  suggestions?: string[];
+}
+
+export default function LocationInput({ label, value, onChange, suggestions = [] }: LocationInputProps) {
+  return (
+    <TagSelectorWithFavorites
+      label={label}
+      value={value}
+      onChange={onChange}
+      allowCustom={true}
+      suggestions={suggestions}
+    />
+  );
+}

--- a/src/components/ProfileSourceSettings.tsx
+++ b/src/components/ProfileSourceSettings.tsx
@@ -24,7 +24,7 @@ const CATEGORY_LABELS = {
   companies: 'Firmen',
   positions: 'Positionen',
   aufgabenbereiche: 'Aufgabenbereiche',
-  orte: 'Orte'
+  orte: 'Ort'
 };
 
 function ProfileSourceSettings({


### PR DESCRIPTION
## Summary
- add `LocationInput` component
- display location next to companies in `ExperienceForm`
- label `orte` as "Ort" in profile source settings

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6872c2b2f8bc8325a9933a20c4147ff3