### PR TITLE
Align input styles in CV editor

### DIFF
--- a/src/components/MonthYearInputBase.tsx
+++ b/src/components/MonthYearInputBase.tsx
@@ -340,8 +340,7 @@ export default function MonthYearInputBase({
       disabled={disabled}
       inputMode="numeric"
       maxLength={7}
-      className={`px-3 py-2 border rounded-md focus:outline-none focus:ring-1 focus:ring-[#F29400] ${className}`}
-      style={{ borderColor: '#D1D5DB' }}
+      className={`w-full h-10 px-3 py-2 text-sm rounded-md border border-gray-300 ${className}`}
     />
   );
 }

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, ChangeEvent } from 'react';
+import type { ChangeEvent } from 'react';
 
 interface TextInputProps {
   value: string;
@@ -35,11 +35,7 @@ export default function TextInput({
         onChange={(e: ChangeEvent<HTMLTextAreaElement>) => onChange(e.target.value)} // specify event type
         placeholder={placeholder}
         rows={rows}
-        className="w-full px-3 py-2 border rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 resize-vertical min-h-[120px]"
-        style={{ 
-          borderColor: '#F29400',
-          '--tw-ring-color': '#F29400'
-        } as CSSProperties}
+        className="w-full h-10 px-3 py-2 text-sm rounded-md border border-gray-300"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- unify `textarea` style in `TextInput`
- unify `input` style in `MonthYearInputBase`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6872d00ddb848325acb5c59a918dca27