### PR TITLE
Unify input styling

### DIFF
--- a/src/components/MonthYearInput.tsx
+++ b/src/components/MonthYearInput.tsx
@@ -59,7 +59,7 @@ export default function MonthYearInput({ value, onChange }: MonthYearInputProps)
       onChange={handleChange}
       onBlur={handleBlur}
       onKeyDown={handleKeyDown}
-      className="w-28"
+      className="w-20"
     />
   );
 }

--- a/src/components/MonthYearInputBase.tsx
+++ b/src/components/MonthYearInputBase.tsx
@@ -340,7 +340,7 @@ export default function MonthYearInputBase({
       disabled={disabled}
       inputMode="numeric"
       maxLength={7}
-      className={`w-full h-10 px-3 py-2 text-sm rounded-md border border-gray-300 ${className}`}
+      className={`w-20 h-10 px-3 py-2 text-sm rounded-md border border-gray-300 ${className}`}
     />
   );
 }

--- a/src/components/ZeitraumPicker.tsx
+++ b/src/components/ZeitraumPicker.tsx
@@ -271,7 +271,7 @@ export default function ZeitraumPicker({
           onBlur={() => setEditingStart(false)}
           onKeyDown={handleStartKeyDown}
           placeholder="von"
-          className={`w-32 ${
+          className={`w-20 ${
             startInvalid ? "border-red-500" : ""
           }`}
         />
@@ -292,7 +292,7 @@ export default function ZeitraumPicker({
             onBlur={() => setEditingEnd(false)}
             onKeyDown={handleEndKeyDown}
             placeholder="bis"
-            className={`w-32 ${
+            className={`w-20 ${
               endInvalid ? "border-red-500" : ""
             }`}
           />


### PR DESCRIPTION
## Summary
- narrow MonthYearInput width
- update MonthYearInputBase default width
- shrink ZeitraumPicker date fields

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872d3b84b80832594fdaa24a1370510