### PR TITLE
Passe Placeholder-Schriftgröße an

### DIFF
--- a/src/components/MonthYearInput.tsx
+++ b/src/components/MonthYearInput.tsx
@@ -59,7 +59,7 @@ export default function MonthYearInput({ value, onChange }: MonthYearInputProps)
       onChange={handleChange}
       onBlur={handleBlur}
       onKeyDown={handleKeyDown}
-      className="w-20"
+      className="w-20 placeholder:text-sm"
     />
   );
 }

--- a/src/components/MonthYearInputBase.tsx
+++ b/src/components/MonthYearInputBase.tsx
@@ -340,7 +340,7 @@ export default function MonthYearInputBase({
       disabled={disabled}
       inputMode="numeric"
       maxLength={7}
-      className={`w-20 h-10 px-3 py-2 text-sm rounded-md border border-gray-300 ${className}`}
+      className={`w-20 h-10 px-3 py-2 text-sm placeholder:text-sm rounded-md border border-gray-300 ${className}`}
     />
   );
 }

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -35,7 +35,7 @@ export default function TextInput({
         onChange={(e: ChangeEvent<HTMLTextAreaElement>) => onChange(e.target.value)} // specify event type
         placeholder={placeholder}
         rows={rows}
-        className="w-full h-10 px-3 py-2 text-sm rounded-md border border-gray-300"
+        className="w-full h-10 px-3 py-2 text-sm placeholder:text-sm rounded-md border border-gray-300"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- ergänze `placeholder:text-sm` bei MonthYearInput
- ergänze `placeholder:text-sm` bei MonthYearInputBase
- ergänze `placeholder:text-sm` in TextInput

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872d849896c832599893f9cee4fc792