### PR TITLE
Fix font sizing for MonthYear inputs

### DIFF
--- a/src/components/MonthYearInput.tsx
+++ b/src/components/MonthYearInput.tsx
@@ -59,7 +59,7 @@ export default function MonthYearInput({ value, onChange }: MonthYearInputProps)
       onChange={handleChange}
       onBlur={handleBlur}
       onKeyDown={handleKeyDown}
-      className="w-20 placeholder:text-sm"
+      className="w-20"
     />
   );
 }

--- a/src/components/MonthYearInputBase.tsx
+++ b/src/components/MonthYearInputBase.tsx
@@ -340,7 +340,7 @@ export default function MonthYearInputBase({
       disabled={disabled}
       inputMode="numeric"
       maxLength={7}
-      className={`w-20 h-10 px-3 py-2 text-sm placeholder:text-sm rounded-md border border-gray-300 ${className}`}
+      className={`w-20 h-10 px-3 py-2 rounded-md border border-gray-300 ${className}`}
     />
   );
 }


### PR DESCRIPTION
## Summary
- normalize font sizing for month/year input components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68736a1e830083259a275f38e2299077