### PR TITLE
Fix width of MonthYearInputBase input

### DIFF
--- a/src/components/MonthYearInputBase.tsx
+++ b/src/components/MonthYearInputBase.tsx
@@ -340,7 +340,7 @@ export default function MonthYearInputBase({
       disabled={disabled}
       inputMode="numeric"
       maxLength={7}
-      className={`w-20 h-10 px-3 py-2 rounded-md border border-gray-300 ${className}`}
+      className={`w-28 h-10 px-3 py-2 rounded-md border border-gray-300 ${className}`}
     />
   );
 }


### PR DESCRIPTION
## Summary
- increase input width so MM/YYYY fields don't clip

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68736bfe59148325b25d73bf47d0c199