### PR TITLE
Bugfix: prevent tag shrinking on edit

### DIFF
--- a/src/components/CompanyTag.tsx
+++ b/src/components/CompanyTag.tsx
@@ -43,7 +43,7 @@ export default function CompanyTag({ label, onRemove, onEdit }: CompanyTagProps)
           onKeyDown={(e) => {
             if (e.key === 'Enter') confirmEdit();
           }}
-          className="text-black px-1 py-0.5 rounded"
+          className="flex-1 text-black px-1 py-0.5 rounded"
           autoFocus
         />
         <button

--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -111,7 +111,7 @@ export default function TagButton({
             onChange={(e) => setEditValue(e.target.value)}
             onBlur={finishEditing}
             onKeyDown={handleEditKey}
-            className="bg-transparent focus:outline-none w-20 text-current px-1"
+            className="bg-transparent focus:outline-none flex-1 text-current px-1"
           />
         ) : (
           <span


### PR DESCRIPTION
## Summary
- allow CompanyTag input to grow with `flex-1`
- remove fixed width from TagButton editing input

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68736dc743f48325a9102f7b8e75c5be