### PR TITLE
UI-Anpassung: Platzhalter & Titelkorrektur

### DIFF
--- a/src/components/CompaniesTagInput.tsx
+++ b/src/components/CompaniesTagInput.tsx
@@ -52,7 +52,7 @@ export default function CompaniesTagInput({ value, onChange, suggestions = [] }:
         onAdd={addCompany}
         onFavoriteClick={handleAddFavoriteInput}
         suggestions={suggestions}
-        placeholder="Firma hinzufügen..."
+        placeholder="Hinzufügen..."
         showFavoritesButton
       />
       

--- a/src/components/ExperienceForm.tsx
+++ b/src/components/ExperienceForm.tsx
@@ -70,7 +70,7 @@ export default function ExperienceForm({
       </div>
 
       <div className="bg-white border border-gray-200 rounded shadow-sm p-4">
-        <h3 className="text-sm font-medium text-gray-700 mb-2">Positionen</h3>
+        <h3 className="text-sm font-medium text-gray-700 mb-2">Position</h3>
         <TagSelectorWithFavorites
           value={selectedPositions}
           onChange={(val) => {


### PR DESCRIPTION
## Summary
- standardisiere Firmen-Placeholder auf "Hinzufügen..."
- korrigiere Titel im Positionsabschnitt zu "Position"

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873704426208325a3866e5ddb460d0a