### PR TITLE
fix: prevent tag-button shrinking on direct edit

### DIFF
--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -111,7 +111,7 @@ export default function TagButton({
             onChange={(e) => setEditValue(e.target.value)}
             onBlur={finishEditing}
             onKeyDown={handleEditKey}
-            className="bg-transparent focus:outline-none flex-1 text-current px-1"
+            className="w-fit max-w-full px-1 bg-transparent outline-none text-current"
           />
         ) : (
           <span


### PR DESCRIPTION
## Summary
- update TagButton input style so editing width stays consistent

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687373f9e0d48325ab6b3aeaf1dd89aa