### PR TITLE
Fix TagButton editing width

### DIFF
--- a/src/components/CompanyTag.tsx
+++ b/src/components/CompanyTag.tsx
@@ -43,7 +43,7 @@ export default function CompanyTag({ label, onRemove, onEdit }: CompanyTagProps)
           onKeyDown={(e) => {
             if (e.key === 'Enter') confirmEdit();
           }}
-          className="w-fit text-black px-1 py-0.5 rounded"
+          className="w-fit min-w-0 text-black px-2 py-1 rounded"
           autoFocus
         />
         <button

--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -111,7 +111,7 @@ export default function TagButton({
             onChange={(e) => setEditValue(e.target.value)}
             onBlur={finishEditing}
             onKeyDown={handleEditKey}
-            className="w-fit max-w-full px-1 bg-transparent outline-none text-current"
+            className="w-fit min-w-0 px-2 py-1 bg-transparent outline-none text-current"
           />
         ) : (
           <span

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -86,7 +86,7 @@ export default function TasksTagInput({ value, onChange }: TasksTagInputProps) {
                     onKeyDown={(e) => {
                       if (e.key === "Enter") confirmEdit();
                     }}
-                    className="w-fit text-black px-1 py-0.5 rounded"
+                    className="w-fit min-w-0 text-black px-2 py-1 rounded"
                     autoFocus
                   />
                   <button


### PR DESCRIPTION
## Summary
- stop shrinking long tags when editing

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687377ddf684832584b8d4f157069803