### PR TITLE
Fix: prevents tag shrink in edit mode

### DIFF
--- a/src/components/CompanyTag.tsx
+++ b/src/components/CompanyTag.tsx
@@ -34,7 +34,7 @@ export default function CompanyTag({ label, onRemove, onEdit }: CompanyTagProps)
 
   if (editing) {
     return (
-      <div className="tag">
+      <div className="tag flex-shrink-0">
         <input
           ref={inputRef}
           value={editValue}

--- a/src/components/JobFieldInput.tsx
+++ b/src/components/JobFieldInput.tsx
@@ -196,7 +196,7 @@ export default function JobFieldInput({ onContentChange, profileConfig }: JobFie
                     {jobFieldData.berufsfelder.map((field) => (
                       <div
                         key={field}
-                        className="inline-flex items-center px-3 py-1 text-white text-sm rounded-full"
+                        className="inline-flex items-center px-3 py-1 text-white text-sm rounded-full flex-shrink-0"
                         style={{ backgroundColor: '#F29400' }}
                       >
                         <span>{field}</span>

--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -103,7 +103,7 @@ export default function TagButton({
       onClick={onClick}
       className={`${baseClasses} ${variantClasses}`}
     >
-      <div className={contentClasses}>
+      <div className={`${contentClasses} flex-shrink-0`}>
         {editing ? (
           <input
             ref={inputRef}

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -78,7 +78,7 @@ export default function TasksTagInput({ value, onChange }: TasksTagInputProps) {
         <div className="flex flex-wrap gap-2">
             {value.map((task, index) => (
               editIndex === index ? (
-                <div key={`${task}-${index}`} className="tag">
+                <div key={`${task}-${index}`} className="tag flex-shrink-0">
                   <input
                     value={editValue}
                     onChange={(e) => setEditValue(e.target.value)}


### PR DESCRIPTION
## Summary
- avoid shrinking tag text while editing
- keep company tags from contracting
- keep task tags from contracting
- keep job field tags from contracting

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68737b55e25c8325b9a4733d263c8a68