### PR TITLE
Fix CV button alignment

### DIFF
--- a/src/components/LebenslaufInput.tsx
+++ b/src/components/LebenslaufInput.tsx
@@ -120,7 +120,7 @@ export default function LebenslaufInput() {
           cvSuggestions={cvSuggestions}
         />
         <button
-          className="w-1/2 mx-auto py-2 rounded-md bg-[#F29400] hover:bg-[#E8850C] text-white text-center"
+          className="block w-1/2 mx-auto py-2 rounded-md bg-[#F29400] hover:bg-[#E8850C] text-white text-center"
           onClick={isEditingExperience ? handleUpdate : handleAdd}
         >
           {isEditingExperience ? 'Aktualisieren' : 'Hinzufügen'}


### PR DESCRIPTION
## Summary
- ensure the add/update button in `LebenslaufInput` is horizontally centered by making it a block element

## Testing
- `npm run lint` *(fails: no-unused-vars errors)*

------
https://chatgpt.com/codex/tasks/task_e_68738d4b21b883258485fc40070efcf9