### PR TITLE
Fix duplicate prevention for tag inputs

### DIFF
--- a/src/components/CompaniesTagInput.tsx
+++ b/src/components/CompaniesTagInput.tsx
@@ -3,7 +3,6 @@ import CompanyTag from './CompanyTag';
 import TagButtonFavorite from './ui/TagButtonFavorite';
 import { useLebenslaufContext } from '../context/LebenslaufContext';
 import AutocompleteInput from './AutocompleteInput';
-import { useTagList } from '../hooks/useTagList';
 
 interface CompaniesTagInputProps {
   value: string[];
@@ -16,15 +15,10 @@ export default function CompaniesTagInput({ value, onChange, suggestions = [] }:
   const { favoriteCompanies: favorites, toggleFavoriteCompany } =
     useLebenslaufContext();
 
-  // unified via useTagList - konsolidierte Tag-Verwaltung
-  const { hasTag } = useTagList({
-    initialTags: value,
-    allowDuplicates: false
-  });
 
   const addCompany = (val?: string) => {
     const c = (val ?? inputValue).trim();
-    if (!c || hasTag(c)) return;
+    if (!c || value.includes(c)) return;
     onChange([...value, c]);
     setInputValue('');
   };

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -1,10 +1,8 @@
 import React, { useState } from "react";
-import { X } from "lucide-react";
 import TaskTag from "./TaskTag";
 import TagButtonFavorite from "./ui/TagButtonFavorite";
 import TextInputWithButtons from "./TextInputWithButtons";
 import { useLebenslaufContext } from "../context/LebenslaufContext";
-import { useTagList } from "../hooks/useTagList";
 import "../styles/_tags.scss";
 
 interface TasksTagInputProps {
@@ -16,16 +14,9 @@ export default function TasksTagInput({ value, onChange }: TasksTagInputProps) {
   const [inputValue, setInputValue] = useState("");
   const { favoriteTasks: favorites, toggleFavoriteTask } = useLebenslaufContext();
 
-  // unified via useTagList - konsolidierte Tag-Verwaltung
-  const { hasTag } = useTagList({
-    initialTags: value,
-    allowDuplicates: false
-  });
-
-
   const addTask = (task?: string) => {
     const t = (task ?? inputValue).trim();
-    if (!t || hasTag(t)) return;
+    if (!t || value.includes(t)) return;
     onChange([...value, t]);
     setInputValue("");
   };


### PR DESCRIPTION
## Summary
- avoid importing `useTagList` in CompaniesTagInput/TasksTagInput
- check existing values directly when adding tags

## Testing
- `npm run lint` *(fails: several pre‑existing lint errors)*
- `node - <<'NODE'
const addCompany = (val, value, inputValue) => {
  const c = (val ?? inputValue).trim();
  if (!c || value.includes(c)) return value;
  return [...value, c];
};
console.log(addCompany('Foo', [], ''));
console.log(addCompany('Foo', ['Foo'], ''));
NODE
`

------
https://chatgpt.com/codex/tasks/task_e_68738eacf0a08325910cc416d297e995