### PR TITLE
feat: Einträge lassen sich über Trash-Icon löschen

### DIFF
--- a/src/components/LebenslaufInput.tsx
+++ b/src/components/LebenslaufInput.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
+import { Trash2 } from 'lucide-react';
 import ExperienceForm from './ExperienceForm';
 import ExperienceSection from './ExperienceSection';
 import CVSection from './CVSection';
@@ -52,6 +53,7 @@ export default function LebenslaufInput() {
     isEditingExperience,
     addExperience,
     updateExperience,
+    deleteExperience,
     selectExperience,
     addEducation,
     updateEducation,
@@ -142,17 +144,29 @@ export default function LebenslaufInput() {
           cvSuggestions={cvSuggestions}
         />
         {hasCurrentExperienceData && (
-          <button
-            type="button"
-            onClick={handleSubmit}
-            className={`block w-[30%] mx-auto text-white font-medium text-sm py-1.5 px-4 rounded-full transition-colors duration-200 ${
-              isEditingExperience
-                ? 'bg-[#207199] hover:bg-[#1A5C80]'
-                : 'bg-[#3E7B0F] hover:bg-[#356A0C]'
-            }`}
-          >
-            {isEditingExperience ? 'Aktualisieren' : 'Hinzufügen'}
-          </button>
+          <div className="flex items-center justify-center space-x-2">
+            <button
+              type="button"
+              onClick={handleSubmit}
+              className={`w-[30%] text-white font-medium text-sm py-1.5 px-4 rounded-full transition-colors duration-200 ${
+                isEditingExperience
+                  ? 'bg-[#207199] hover:bg-[#1A5C80]'
+                  : 'bg-[#3E7B0F] hover:bg-[#356A0C]'
+              }`}
+            >
+              {isEditingExperience ? 'Aktualisieren' : 'Hinzufügen'}
+            </button>
+            {isEditingExperience && selectedExperienceId && (
+              <button
+                type="button"
+                onClick={() => deleteExperience(selectedExperienceId)}
+                className="p-2 text-red-600 hover:bg-red-50 rounded-full transition-colors duration-200"
+                title="Eintrag löschen"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            )}
+          </div>
         )}
       </ExperienceSection>
 

--- a/src/context/LebenslaufContext.tsx
+++ b/src/context/LebenslaufContext.tsx
@@ -55,6 +55,7 @@ interface LebenslaufContextType {
   isEditingExperience: boolean;
   addExperience: (data: Omit<Berufserfahrung, 'id'>) => Promise<void>;
   updateExperience: (id: string, data: Omit<Berufserfahrung, 'id'>) => Promise<void>;
+  deleteExperience: (id: string) => Promise<void>;
   selectExperience: (id: string | null) => void;
   addEducation: (data: Omit<AusbildungEntry, 'id'>) => Promise<void>;
   updateEducation: (id: string, data: Omit<AusbildungEntry, 'id'>) => Promise<void>;
@@ -164,6 +165,16 @@ export function LebenslaufProvider({
       return updated;
     });
     // Persisting to Supabase removed
+    setIsEditingExperience(false);
+  };
+
+  const deleteExperience = async (id: string) => {
+    setBerufserfahrungen(prev => {
+      const updated = prev.filter(exp => exp.id !== id);
+      localStorage.setItem(LOCAL_KEY, JSON.stringify(updated));
+      return updated;
+    });
+    setSelectedExperienceId(null);
     setIsEditingExperience(false);
   };
 
@@ -279,6 +290,7 @@ export function LebenslaufProvider({
         isEditingExperience,
         addExperience,
         updateExperience,
+        deleteExperience,
         selectExperience,
         addEducation,
         updateEducation,


### PR DESCRIPTION
## Summary
- add `deleteExperience` to context
- allow deleting an experience entry via trash icon button

## Testing
- `npm run lint` *(fails: several pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6873c0fb2da08325b3ae7258d24493a4