### PR TITLE
Designfix Fokusfarbe & Favoritenhintergrund

### DIFF
--- a/src/components/MonthYearInputBase.tsx
+++ b/src/components/MonthYearInputBase.tsx
@@ -340,7 +340,8 @@ export default function MonthYearInputBase({
       disabled={disabled}
       inputMode="numeric"
       maxLength={7}
-      className={`w-28 h-10 px-3 py-2 rounded-md border border-gray-300 ${className}`}
+      className={`w-28 h-10 px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:ring-2 ${className}`}
+      style={{ '--tw-ring-color': '#F29400' } as React.CSSProperties}
     />
   );
 }

--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -52,7 +52,7 @@ export default function TagButton({
   } else if (variant === TagContext.Suggestion) {
     variantClasses = "bg-white text-gray-700 border-gray-300";
   } else if (variant === TagContext.Favorite) {
-    variantClasses = "bg-[#fffbec] text-gray-800 border-[#FDE047] px-3";
+    variantClasses = "bg-[#FFF5E2] text-gray-800 border-[#FDE047] px-3";
   } else {
     variantClasses = "bg-white text-gray-700 border-[#F29400]";
   }


### PR DESCRIPTION
## Summary
- update focus style for `MonthYearInputBase` to orange
- lighten favorite tag background

## Testing
- `npx eslint src/components/MonthYearInputBase.tsx src/components/TagButton.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6873cb9a16208325b3d9ab5a69950338