### PR TITLE
Tag-Buttons über Eingabefeldern

### DIFF
--- a/src/components/AufgabenbereichInput.tsx
+++ b/src/components/AufgabenbereichInput.tsx
@@ -100,6 +100,52 @@ export default function AufgabenbereichInput({
     <div className="space-y-4">
       <h3 className="text-sm font-medium text-gray-700">Aufgaben/Tätigkeiten</h3>
 
+      {value.length > 0 && (
+        <div>
+          <h4 className="text-sm font-medium text-gray-700 mb-2">Ausgewählt:</h4>
+          <div className="flex flex-wrap gap-2">
+            {value.map((task, index) => (
+              <div
+                key={`${task}-${index}`}
+                className="inline-flex items-center px-3 py-1 text-sm rounded-full text-white"
+                style={{ backgroundColor: '#F29400' }}
+              >
+              {editIndex === index ? (
+                <input
+                  value={editValue}
+                  onChange={(e) => setEditValue(e.target.value)}
+                  onBlur={confirmEdit}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') confirmEdit();
+                  }}
+                  className="text-black px-1 py-0.5 rounded"
+                  autoFocus
+                />
+              ) : (
+                <span className="mr-2">{task}</span>
+              )}
+              {editIndex !== index && (
+                <button
+                  onClick={() => startEdit(index)}
+                  className="mr-1 text-white hover:text-gray-200"
+                  aria-label="Bearbeiten"
+                >
+                  <Pencil className="h-3 w-3" />
+                </button>
+              )}
+              <button
+                onClick={() => removeTask(task)}
+                className="text-white hover:text-gray-200"
+                aria-label="Entfernen"
+              >
+                <X className="h-3 w-3" />
+              </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       <AutocompleteInput
         value={inputValue}
         onChange={setInputValue}
@@ -147,52 +193,6 @@ export default function AufgabenbereichInput({
               </button>
             </div>
           ))}
-        </div>
-      )}
-
-      {value.length > 0 && (
-        <div>
-          <h4 className="text-sm font-medium text-gray-700 mb-2">Ausgewählt:</h4>
-          <div className="flex flex-wrap gap-2">
-            {value.map((task, index) => (
-              <div
-                key={`${task}-${index}`}
-                className="inline-flex items-center px-3 py-1 text-sm rounded-full text-white"
-                style={{ backgroundColor: '#F29400' }}
-              >
-              {editIndex === index ? (
-                <input
-                  value={editValue}
-                  onChange={(e) => setEditValue(e.target.value)}
-                  onBlur={confirmEdit}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') confirmEdit();
-                  }}
-                  className="text-black px-1 py-0.5 rounded"
-                  autoFocus
-                />
-              ) : (
-                <span className="mr-2">{task}</span>
-              )}
-              {editIndex !== index && (
-                <button
-                  onClick={() => startEdit(index)}
-                  className="mr-1 text-white hover:text-gray-200"
-                  aria-label="Bearbeiten"
-                >
-                  <Pencil className="h-3 w-3" />
-                </button>
-              )}
-              <button
-                onClick={() => removeTask(task)}
-                className="text-white hover:text-gray-200"
-                aria-label="Entfernen"
-              >
-                <X className="h-3 w-3" />
-              </button>
-              </div>
-            ))}
-          </div>
         </div>
       )}
 

--- a/src/components/CompaniesTagInput.tsx
+++ b/src/components/CompaniesTagInput.tsx
@@ -40,16 +40,6 @@ export default function CompaniesTagInput({ value, onChange, suggestions = [] }:
 
   return (
     <div className="space-y-2">
-      <AutocompleteInput
-        value={inputValue}
-        onChange={setInputValue}
-        onAdd={addCompany}
-        onFavoriteClick={handleAddFavoriteInput}
-        suggestions={suggestions}
-        placeholder="Hinzufügen..."
-        showFavoritesButton
-      />
-      
       {value.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {value.map((c) => (
@@ -62,6 +52,16 @@ export default function CompaniesTagInput({ value, onChange, suggestions = [] }:
           ))}
         </div>
       )}
+
+      <AutocompleteInput
+        value={inputValue}
+        onChange={setInputValue}
+        onAdd={addCompany}
+        onFavoriteClick={handleAddFavoriteInput}
+        suggestions={suggestions}
+        placeholder="Hinzufügen..."
+        showFavoritesButton
+      />
 
       {favorites.filter((f) => !value.includes(f)).length > 0 && (
         <div>

--- a/src/components/JobFieldInput.tsx
+++ b/src/components/JobFieldInput.tsx
@@ -208,24 +208,6 @@ export default function JobFieldInput({ onContentChange, profileConfig }: JobFie
           {expandedSections.berufsfelder && (
             <div id="berufsfelder-content" className="p-4 space-y-4">
               {/* BOLT-UI-ANPASSUNG 2025-01-15: Custom Input mit Autocomplete - Platzhaltertext angepasst */}
-              <div>
-                <AutocompleteInput
-                  id="job-field-input"
-                  label="Berufsfeld eingeben:"
-                  value={customInput}
-                  onChange={setCustomInput}
-                  onAdd={addJobField}
-                  suggestions={profileConfig.berufe}
-                  className="text-black px-2 py-1 rounded bg-white"
-                  size={editValue.length || 1}
-                  style={{ 
-                    width: `${editValue.length * 0.8 + 1}ch`,
-                    minWidth: `${editValue.length * 0.8 + 1}ch`
-                  }}
-                  buttonColor="orange"
-                />
-              </div>
-
               {/* Selected Job Fields with Favorites Button */}
               {jobFieldData.berufsfelder.length > 0 && (
                 <div>
@@ -271,6 +253,24 @@ export default function JobFieldInput({ onContentChange, profileConfig }: JobFie
                   </div>
                 </div>
               )}
+
+              <div>
+                <AutocompleteInput
+                  id="job-field-input"
+                  label="Berufsfeld eingeben:"
+                  value={customInput}
+                  onChange={setCustomInput}
+                  onAdd={addJobField}
+                  suggestions={profileConfig.berufe}
+                  className="text-black px-2 py-1 rounded bg-white"
+                  size={editValue.length || 1}
+                  style={{
+                    width: `${editValue.length * 0.8 + 1}ch`,
+                    minWidth: `${editValue.length * 0.8 + 1}ch`
+                  }}
+                  buttonColor="orange"
+                />
+              </div>
 
               {/* Favorite Options - ORANGE UMRANDUNG + X INNERHALB */}
               {favoriteItems.length > 0 && (

--- a/src/components/ProfileInput.tsx
+++ b/src/components/ProfileInput.tsx
@@ -252,20 +252,6 @@ export default function ProfileInput({ onContentChange, profileConfig, initialCo
 
         {isExpanded && (
           <div id={`${sectionId}-content`} className="p-4 space-y-4">
-            {/* BOLT-UI-ANPASSUNG 2025-01-15: Custom Input mit Autocomplete - Platzhaltertext angepasst */}
-            <div>
-              <AutocompleteInput
-                id={customInputId}
-                label={`${title} eingeben:`}
-                value={customInputs[category]}
-                onChange={(value) => setCustomInputs({ ...customInputs, [category]: value })}
-                onAdd={(valueToAdd) => addCustomItem(category, valueToAdd)}
-                suggestions={availableItems}
-                placeholder="Hinzufügen..." // BOLT-UI-ANPASSUNG 2025-01-15: Platzhaltertext angepasst
-                buttonColor="orange"
-              />
-            </div>
-
             {/* Selected Items with Favorites Button */}
             {selectedItems.length > 0 && (
               <div>
@@ -311,6 +297,19 @@ export default function ProfileInput({ onContentChange, profileConfig, initialCo
                 </div>
               </div>
             )}
+
+            <div>
+              <AutocompleteInput
+                id={customInputId}
+                label={`${title} eingeben:`}
+                value={customInputs[category]}
+                onChange={(value) => setCustomInputs({ ...customInputs, [category]: value })}
+                onAdd={(valueToAdd) => addCustomItem(category, valueToAdd)}
+                suggestions={availableItems}
+                placeholder="Hinzufügen..." // BOLT-UI-ANPASSUNG 2025-01-15: Platzhaltertext angepasst
+                buttonColor="orange"
+              />
+            </div>
 
             {/* Favorite Options - ORANGE UMRANDUNG + X INNERHALB */}
             {favoriteItems.length > 0 && (

--- a/src/components/TagSelectorWithFavorites.tsx
+++ b/src/components/TagSelectorWithFavorites.tsx
@@ -67,18 +67,6 @@ export default function TagSelectorWithFavorites({
 
   return (
     <div className="space-y-4">
-      <AutocompleteInput
-        value={inputValue}
-        onChange={setInputValue}
-        onAdd={handleAddInput}
-        onFavoriteClick={handleAddFavoriteInput}
-        suggestions={suggestions ?? options}
-        placeholder="Hinzufügen..."
-        showFavoritesButton
-        showAddButton
-        label={label}
-      />
-
       {value.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {value.map((tag, index) => (
@@ -91,6 +79,18 @@ export default function TagSelectorWithFavorites({
           ))}
         </div>
       )}
+
+      <AutocompleteInput
+        value={inputValue}
+        onChange={setInputValue}
+        onAdd={handleAddInput}
+        onFavoriteClick={handleAddFavoriteInput}
+        suggestions={suggestions ?? options}
+        placeholder="Hinzufügen..."
+        showFavoritesButton
+        showAddButton
+        label={label}
+      />
 
       {favorites.filter((f) => !value.includes(f)).length > 0 && (
         <div>

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -45,14 +45,6 @@ export default function TasksTagInput({ value, onChange }: TasksTagInputProps) {
   return (
     <div className="space-y-4">
 
-      <TextInputWithButtons
-        value={inputValue}
-        onChange={setInputValue}
-        onAdd={addTask}
-        onFavoriteClick={handleAddFavoriteInput}
-        placeholder="Hinzufügen..."
-      />
-
       {value.length > 0 && (
         <div className="flex flex-wrap gap-2">
             {value.map((task, index) => (
@@ -65,6 +57,14 @@ export default function TasksTagInput({ value, onChange }: TasksTagInputProps) {
             ))}
           </div>
       )}
+
+      <TextInputWithButtons
+        value={inputValue}
+        onChange={setInputValue}
+        onAdd={addTask}
+        onFavoriteClick={handleAddFavoriteInput}
+        placeholder="Hinzufügen..."
+      />
 
 
       {favorites.filter((f) => !value.includes(f)).length > 0 && (


### PR DESCRIPTION
## Summary
- reorder tag rendering in several input components
- job field and profile input sections show selected tags above inputs
- tasks and companies show tags before the corresponding inputs
- tag selector with favorites displays selected positions on top

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js' before installing; after installing, linter reports existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6873cfc86d5883259a8d0c81e8aa374b