### PR TITLE
Spacing-Fix: Unternehmen & Ort

### DIFF
--- a/src/components/ExperienceForm.tsx
+++ b/src/components/ExperienceForm.tsx
@@ -100,13 +100,11 @@ export default function ExperienceForm({
             </button>
           )}
         </div>
-        <div className="w-full">
-          <CompaniesTagInput
-            value={form.companies}
-            onChange={(val) => onUpdateField('companies', val)}
-            suggestions={cvSuggestions.companies}
-          />
-        </div>
+        <CompaniesTagInput
+          value={form.companies}
+          onChange={(val) => onUpdateField('companies', val)}
+          suggestions={cvSuggestions.companies}
+        />
       </div>
 
       <div className="bg-white border border-gray-200 rounded shadow-sm p-4">


### PR DESCRIPTION
## Summary
- fix spacing in `ExperienceForm` around `CompaniesTagInput`

## Testing
- `npm run lint` *(fails: several unused variable errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6873d2d8ce448325b737f6468a5f34de