### PR TITLE
fix: Tag-Spacing bei Unternehmen & Ort

### DIFF
--- a/src/components/CompaniesTagInput.tsx
+++ b/src/components/CompaniesTagInput.tsx
@@ -41,7 +41,7 @@ export default function CompaniesTagInput({ value, onChange, suggestions = [] }:
   return (
     <div className="space-y-2">
       {value.length > 0 && (
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-2 mb-4">
           {value.map((c) => (
             <CompanyTag
               key={c}


### PR DESCRIPTION
## Summary
- adjust vertical spacing for selected companies

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6873d53669b48325ad49225b2ca0892b