### PR TITLE
Favoriten-Button-Styling vereinheitlichen

### DIFF
--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -53,7 +53,7 @@ export default function TagButton({
   } else if (variant === TagContext.Suggestion) {
     variantClasses = "bg-white text-gray-700 border-gray-300";
   } else if (variant === TagContext.Favorite) {
-    variantClasses = "bg-transparent border-[#F29400] border text-black";
+    variantClasses = "bg-[#f8f8f8] border-[#FDE047] text-black";
   } else {
     variantClasses = "bg-white text-gray-700 border-[#F29400]";
   }


### PR DESCRIPTION
## Summary
- style TagButton so that favorite variant has light gray background and yellow border

## Testing
- `npm run lint` *(fails: cannot find '@eslint/js' or other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6873de381908832590c3a0ca3026b834