### PR TITLE
style: selected tag button smaller & bold

### DIFF
--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -49,7 +49,7 @@ export default function TagButton({
   let variantClasses = "";
   if (variant === TagContext.Selected) {
     variantClasses =
-      "bg-[#F29400] text-white border-[#F29400] px-4 py-2 text-lg";
+      "bg-[#F29400] text-white border-[#F29400] text-xs font-bold px-3 py-1";
   } else if (variant === TagContext.Suggestion) {
     variantClasses = "bg-white text-gray-700 border-gray-300";
   } else if (variant === TagContext.Favorite) {

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,8 @@
 @import url("https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap");
 @tailwind base;
 @tailwind components;
-@tailwind utilities;
-
 @import "./styles/_tags.scss";
+@tailwind utilities;
 @import "./styles/tailwind.css";
 @layer base {
   body {

--- a/src/styles/_tags.scss
+++ b/src/styles/_tags.scss
@@ -3,7 +3,6 @@
   align-items: center;
   padding: 0.25rem 0.75rem;
   border-radius: 9999px;
-  font-size: 0.875rem;
   border: 1px solid transparent;
   transition: background-color 0.2s;
 }


### PR DESCRIPTION
## Summary
- tweak `_tags.scss` by dropping base font-size
- import tags styles before utilities in `index.css`
- style selected `TagButton` variant as bold 12px

## Testing
- `npm run lint` *(fails: no-unused-vars in unrelated files)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6873e49b3d288325ae16f44cb25edd88