### PR TITLE
style: kompakteres Padding für Favoriten-TagButtons

### DIFF
--- a/src/components/TagButton.tsx
+++ b/src/components/TagButton.tsx
@@ -135,8 +135,8 @@ export default function TagButton({
   if (variant === TagContext.Selected) {
     buttonStyle = { padding: '0.25rem 0.75rem' };
   } else if (variant === TagContext.Favorite) {
-    buttonStyle = { 
-      padding: '0.25rem 0.5rem',
+    buttonStyle = {
+      padding: '0.125rem 0.375rem',
       borderWidth: '2px',
       borderColor: '#ffde59'
     };

--- a/src/styles/_tags.scss
+++ b/src/styles/_tags.scss
@@ -45,7 +45,7 @@
   color: #4b5563;
   border-color: #ffde59;
   border-width: 2px;
-  padding: 0.25rem 0.5rem;
+  padding: 0.125rem 0.375rem;
   font-size: 0.875rem;
   font-weight: 400;
   line-height: 1;


### PR DESCRIPTION
## Summary
- shrink favorite TagButton padding to 0.125rem 0.375rem
- update SCSS styles for `.tag--favorite`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68740b74440c8325ba829d7a5a0a684c