### PR TITLE
feature: TextInput mit Lösch-Button

### DIFF
--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -1,4 +1,5 @@
 import type { ChangeEvent } from 'react';
+import { X } from 'lucide-react';
 
 interface TextInputProps {
   value: string;
@@ -22,21 +23,33 @@ export default function TextInput({
   // Generate unique ID if not provided
   const textareaId = id || `textarea-${Math.random().toString(36).substr(2, 9)}`;
   const textareaName = name || `textarea-${textareaId}`;
+  const hasValue = value.trim().length > 0;
 
   return (
     <div className="space-y-2">
       <label htmlFor={textareaId} className="block text-sm font-medium text-gray-700">
         {label}
       </label>
-      <textarea
-        id={textareaId}
-        name={textareaName}
-        value={value}
-        onChange={(e: ChangeEvent<HTMLTextAreaElement>) => onChange(e.target.value)} // specify event type
-        placeholder={placeholder}
-        rows={rows}
-        className="w-full h-10 px-3 py-2 text-sm placeholder:text-sm rounded-md border border-gray-300"
-      />
+      <div className="relative">
+        <textarea
+          id={textareaId}
+          name={textareaName}
+          value={value}
+          onChange={(e: ChangeEvent<HTMLTextAreaElement>) => onChange(e.target.value)}
+          placeholder={placeholder}
+          rows={rows}
+          className="w-full h-10 px-3 py-2 text-sm placeholder:text-sm rounded-md border border-gray-300"
+        />
+        {hasValue && (
+          <button
+            type="button"
+            onClick={() => onChange('')}
+            className="absolute top-1 right-1 text-gray-400 hover:text-gray-600"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `X` icon to TextInput
- show clear button when text is entered

## Testing
- `npm run lint` *(fails: several pre-existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68740df698f4832592e8d9403dd5fd07