### PR TITLE
Fix width of tag inputs

### DIFF
--- a/src/components/AutocompleteInput.tsx
+++ b/src/components/AutocompleteInput.tsx
@@ -210,7 +210,7 @@ export default function AutocompleteInput({
           {label}
         </label>
       )}
-      <div className="flex items-center w-full">
+      <div className="flex items-center w-full space-x-2"> // Hinzugefügt: space-x-2
         <div className="relative flex-1">
           <input
             ref={inputRef}
@@ -247,7 +247,7 @@ export default function AutocompleteInput({
         </div>
 
         {hasInput && (
-          <div className="flex gap-2 ml-2">
+          <div className="flex-shrink-0 flex"> // Entfernt: gap-2 und ml-2
             {/* Add button */}
             {showAddButton && (
               <button

--- a/src/components/CompaniesTagInput.tsx
+++ b/src/components/CompaniesTagInput.tsx
@@ -61,6 +61,7 @@ export default function CompaniesTagInput({ value, onChange, suggestions = [] }:
         suggestions={suggestions}
         placeholder="Hinzufügen..."
         showFavoritesButton
+        className="w-full" // Hinzugefügt: Stellt sicher, dass die Komponente die volle Breite einnimmt
       />
 
       {favorites.filter((f) => !value.includes(f)).length > 0 && (

--- a/src/components/TagSelectorWithFavorites.tsx
+++ b/src/components/TagSelectorWithFavorites.tsx
@@ -90,6 +90,7 @@ export default function TagSelectorWithFavorites({
         showFavoritesButton
         showAddButton
         label={label}
+        className="w-full" // Hinzugefügt: Stellt sicher, dass die Komponente die volle Breite einnimmt
       />
 
       {favorites.filter((f) => !value.includes(f)).length > 0 && (

--- a/src/components/TasksTagInput.tsx
+++ b/src/components/TasksTagInput.tsx
@@ -64,6 +64,7 @@ export default function TasksTagInput({ value, onChange }: TasksTagInputProps) {
         onAdd={addTask}
         onFavoriteClick={handleAddFavoriteInput}
         placeholder="Hinzufügen..."
+        className="w-full" // Hinzugefügt: Stellt sicher, dass die Komponente die volle Breite einnimmt
       />
 
 

--- a/src/components/TextInputWithButtons.tsx
+++ b/src/components/TextInputWithButtons.tsx
@@ -42,7 +42,7 @@ export default function TextInputWithButtons({
   };
 
   return (
-    <div className="flex items-center w-full">
+    <div className="flex items-center w-full space-x-2"> // Hinzugefügt: space-x-2
       <div className="relative flex-1">
         <input
           type="text"
@@ -64,7 +64,7 @@ export default function TextInputWithButtons({
         )}
       </div>
       {buttonsVisible && (
-        <div className="flex-shrink-0 flex gap-2 ml-2">
+        <div className="flex-shrink-0 flex"> // Entfernt: gap-2 und ml-2
           <button
             type="button"
             onClick={handleAdd}


### PR DESCRIPTION
## Summary
- ensure tag input components take up full width
- adjust spacing of input buttons

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6874173d61588325b500d73b0b89a8b7