### PR TITLE
Fix spacing comments removal

### DIFF
--- a/src/components/AutocompleteInput.tsx
+++ b/src/components/AutocompleteInput.tsx
@@ -210,7 +210,7 @@ export default function AutocompleteInput({
           {label}
         </label>
       )}
-      <div className="flex items-center w-full space-x-2"> // Hinzugefügt: space-x-2
+      <div className="flex items-center w-full space-x-2">
         <div className="relative flex-1">
           <input
             ref={inputRef}

--- a/src/components/TextInputWithButtons.tsx
+++ b/src/components/TextInputWithButtons.tsx
@@ -42,7 +42,7 @@ export default function TextInputWithButtons({
   };
 
   return (
-    <div className="flex items-center w-full space-x-2"> // Hinzugefügt: space-x-2
+    <div className="flex items-center w-full space-x-2">
       <div className="relative flex-1">
         <input
           type="text"


### PR DESCRIPTION
## Summary
- remove leftover `Hinzugefügt: space-x-2` comments from inputs

## Testing
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6874193ccee88325a178836cf630fa3a