### PR TITLE
fix: Fokus bleibt im Eingabefeld nach Klick auf 'X'-Button

### DIFF
--- a/src/components/AutocompleteInput.tsx
+++ b/src/components/AutocompleteInput.tsx
@@ -237,7 +237,11 @@ export default function AutocompleteInput({
           {hasInput && (
             <button
               type="button"
-              onClick={() => onChange('')}
+              onClick={(e) => {
+                e.preventDefault();
+                onChange('');
+                inputRef.current?.focus();
+              }}
               className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 rounded-full focus:outline-none focus:ring-2 focus:ring-gray-300"
               aria-label="Textfeld leeren"
             >

--- a/src/components/TextInputWithButtons.tsx
+++ b/src/components/TextInputWithButtons.tsx
@@ -1,5 +1,5 @@
 import { Plus, Star, X } from 'lucide-react';
-import type { ChangeEvent, KeyboardEvent } from 'react';
+import { useRef, type ChangeEvent, type KeyboardEvent } from 'react';
 
 interface TextInputWithButtonsProps {
   value: string;
@@ -21,6 +21,8 @@ export default function TextInputWithButtons({
   const trimmed = value.trim();
   const hasValue = trimmed.length > 0;
   const buttonsVisible = showButtons ?? hasValue;
+
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const handleAdd = () => {
     if (!hasValue) return;
@@ -45,6 +47,7 @@ export default function TextInputWithButtons({
     <div className="flex items-center w-full space-x-2">
       <div className="relative flex-1">
         <input
+          ref={inputRef}
           type="text"
           value={value}
           onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
@@ -52,16 +55,20 @@ export default function TextInputWithButtons({
           placeholder={placeholder}
           className="w-full px-3 h-10 border rounded-md transition-all focus:outline-none focus:ring-1 focus:ring-[#F29400] pr-10"
         />
-        {hasValue && (
-          <button
-            type="button"
-            onClick={() => onChange('')}
-            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 rounded-full focus:outline-none focus:ring-2 focus:ring-gray-300"
-            aria-label="Textfeld leeren"
-          >
-            <X className="w-4 h-4" />
-          </button>
-        )}
+          {hasValue && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.preventDefault();
+                onChange('');
+                inputRef.current?.focus();
+              }}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 rounded-full focus:outline-none focus:ring-2 focus:ring-gray-300"
+              aria-label="Textfeld leeren"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          )}
       </div>
       {buttonsVisible && (
         <div className="flex-shrink-0 flex space-x-2">


### PR DESCRIPTION
## Summary
- prevent input blur when clearing AutocompleteInput
- keep focus on TextInputWithButtons when clearing value

## Testing
- `npm run lint` *(fails: several unused variable errors)*

------
https://chatgpt.com/codex/tasks/task_e_6874218649e083258550e1922ddfed82